### PR TITLE
Add additional request headers

### DIFF
--- a/lib/admin/utils.rb
+++ b/lib/admin/utils.rb
@@ -37,6 +37,8 @@ module AdminUI
 
       request.body = body
       request['Authorization'] = authorization_header
+      request['Accept'] = 'application/json;charset=utf-8'
+      request['Content-Type'] = 'application/x-www-form-urlencoded;charset=utf-8'
 
       http.request(request)
     end


### PR DESCRIPTION
These headers are provided by the CF command line client and seemed to be necessary for PCF 1.0.1 compatibility.

Thanks
Nibedita
