### PR TITLE
fixed errors in admin_spec.rb

### DIFF
--- a/spec/support/server_helper.rb
+++ b/spec/support/server_helper.rb
@@ -14,7 +14,7 @@ shared_context :server_context do
   let(:log_file_displayed) { '/tmp/admin_ui_displayed.log' }
   let(:log_file_displayed_contents) { 'These are test log file contents' }
   let(:log_file_displayed_contents_length) { log_file_displayed_contents.length }
-  let(:log_file_displayed_modified) { Time.now }
+  let(:log_file_displayed_modified) { Time.new(1976, 07, 04, 12, 34, 56, 0) }
   let(:log_file_displayed_modified_milliseconds) { AdminUI::Utils.time_in_milliseconds(log_file_displayed_modified) }
   let(:log_file_page_size) { 100 }
   let(:stats_file) { '/tmp/admin_ui_stats.json' }

--- a/spec/unit/log_files_spec.rb
+++ b/spec/unit/log_files_spec.rb
@@ -18,7 +18,7 @@ describe AdminUI::LogFiles do
   let(:log_file_name) { 'test' }
   let(:log_file_extension) { 'log' }
   let(:log_file_content) { 'This is sample file content.  It is not really very long.  But, will suffice for testing' }
-  let(:log_file_mtime) { Time.now }
+  let(:log_file_mtime) {  Time.new(1976, 07, 04, 12, 34, 56, 0) }
 
   before do
     AdminUI::Config.any_instance.stub(:validate)


### PR DESCRIPTION
This change aimed at fixing the following test case failures:

rspec ./spec/integration/admin_spec.rb:203 # AdminUI::Admin retrieves and validates logs retrieves
rspec ./spec/integration/admin_spec.rb:303 # AdminUI::Admin tasks creates DEA, retrieves all tasks and retrieves specific status

  1) AdminUI::Admin retrieves and validates logs retrieves
     Failure/Error: expect(item).to include('path' => log_file_displayed,
       expected {"path"=>"/tmp/admin_ui_displayed.log", "size"=>32, "time"=>1395784913000} to include {"path"=>"/tmp/admin_ui_displayed.log", "size"=>32, "time"=>1395784913735}
       Diff:
       @@ -1,2 +1,4 @@
       -[{"path"=>"/tmp/admin_ui_displayed.log", "size"=>32, "time"=>1395784913735}]
       +"path" => "/tmp/admin_ui_displayed.log",
       +"size" => 32,
       +"time" => 1395784913000
     # ./spec/integration/admin_spec.rb:208:in `block (4 levels) in <top (required)>'

  2) AdminUI::Admin tasks creates DEA, retrieves all tasks and retrieves specific status
     Failure/Error: expect(found_out).to be_true
       expected: true value
            got: false
     # ./spec/integration/admin_spec.rb:341:in `block (3 levels) in <top (required)>'
