### PR TITLE
Hide differences in certain network error messages

### DIFF
--- a/spec/integration/varz_spec.rb
+++ b/spec/integration/varz_spec.rb
@@ -33,35 +33,36 @@ describe AdminUI::VARZ, :type => :integration do
 
       expect(components['connected']).to eq(true)
       items = components['items']
+      items.each { |i| i.delete('error') }
       expect(items.length).to be(5)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_cloud_controller,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_cloud_controller['host'],
                                'uri'       => nats_cloud_controller_varz)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_dea,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_dea['host'],
                                'uri'       => nats_dea_varz)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_health_manager,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_health_manager['host'],
                                'uri'       => nats_health_manager_varz)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_router,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_router['host'],
                                'uri'       => nats_router_varz)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_provisioner,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_provisioner['host'],
                                'uri'       => nats_provisioner_varz)
     end
@@ -71,11 +72,12 @@ describe AdminUI::VARZ, :type => :integration do
 
       expect(cloud_controllers['connected']).to eq(true)
       items = cloud_controllers['items']
+      items.each { |i| i.delete('error') }
       expect(items.length).to be(1)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_cloud_controller,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_cloud_controller['host'],
                                'uri'       => nats_cloud_controller_varz)
     end
@@ -85,11 +87,12 @@ describe AdminUI::VARZ, :type => :integration do
 
       expect(deas['connected']).to eq(true)
       items = deas['items']
+      items.each { |i| i.delete('error') }
       expect(items.length).to be(1)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_dea,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_dea['host'],
                                'uri'       => nats_dea_varz)
     end
@@ -103,11 +106,12 @@ describe AdminUI::VARZ, :type => :integration do
 
       expect(health_managers['connected']).to eq(true)
       items = health_managers['items']
+      items.each { |i| i.delete('error') }
       expect(items.length).to be(1)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_health_manager,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_health_manager['host'],
                                'uri'       => nats_health_manager_varz)
     end
@@ -117,11 +121,12 @@ describe AdminUI::VARZ, :type => :integration do
 
       expect(gateways['connected']).to eq(true)
       items = gateways['items']
+      items.each { |i| i.delete('error') }
       expect(items.length).to be(1)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_provisioner,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_provisioner['type'].sub('-Provisioner', ''),
                                'uri'       => nats_provisioner_varz)
     end
@@ -131,11 +136,12 @@ describe AdminUI::VARZ, :type => :integration do
 
       expect(routers['connected']).to eq(true)
       items = routers['items']
+      items.each { |i| i.delete('error') }
       expect(items.length).to be(1)
 
       expect(items).to include('connected' => false,
                                'data'      => nats_router,
-                               'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
+                               # 'error'     => '#<SocketError: getaddrinfo: Name or service not known>',
                                'name'      => nats_router['host'],
                                'uri'       => nats_router_varz)
     end


### PR DESCRIPTION
the network based error messages are slightly different on different operating systems.  Until/unless we can find a way to mask just certain parts of the error message I think, for now, we need to skip the text matching on the error text.

I left the old error text/check in there in case we find a way to diff it later.  If we never do then we can remove it.
