### PR TITLE
Don't worry about the fact that we suppress exceptions in our rspec tests

### DIFF
--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - ../.rubocop.yml
+
+HandleExceptions:
+  Enabled: false


### PR DESCRIPTION
Right now we suppress some exceptions in our rspec tests.  These are identified by rubocop as problems.  We want to instead ignore these in the rspec tests.
