### PR TITLE
added build status button to README.md page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://api.travis-ci.org/cloudfoundry-incubator/admin-ui.png)](https://travis-ci.org/cloudfoundry-incubator/admin-ui)
 # Administration Web UI for CloudFoundry NG 
 
 The Administration Web UI provides metrics and operations data for CloudFoundry NG.


### PR DESCRIPTION
This change adds build status button to the README.md page.  In the same fashion of build status buttons on other components' README.md pages, a click on this button takes user to the admin-ui's travis-ic build page.
