### PR TITLE
Fixed a typo in the word 'exuecute'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ from the cloud controller and UAA REST API's.
 
 ## Placement
 
-In order to exeucute, the administration ui needs to be able to access the following resources:
+In order to execute, the administration ui needs to be able to access the following resources:
 
 - NATS
 - Cloud controller REST API


### PR DESCRIPTION
This is a simple one character change to the repo's README file.
