### PR TITLE
After app mgmt change, change default sorting back to started column

### DIFF
--- a/lib/admin/public/js/app/tabs/applicationsTab.js
+++ b/lib/admin/public/js/app/tabs/applicationsTab.js
@@ -49,7 +49,7 @@ ApplicationsTab.prototype.checkboxClickHandler = function(event)
 
 ApplicationsTab.prototype.getInitialSort = function()
 {
-    return [[4, "desc"]];
+    return [[5, "desc"]];
 }
 
 ApplicationsTab.prototype.getColumns = function()


### PR DESCRIPTION
Default sorting of app tab accidentally changed.  Moving it back to the started column.
