### PR TITLE
revert key to be in plain text for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ rvm:
 addons:
   sauce_connect:
     username: 'admin-ui'
-    access_key:
-      secure: "ZHw5o9aH8zL/c6iwVTv9/7STggk9IiedZh0jrw3DQqZtu6K6G04iIF+S/5EDiCIcZj+EARoZsk1TPO8v+OS0WpZoxSo2of04tWA0cfXnkc5R2hdjDIsUJxJC1/xkDwCpCuTKIvf9yh3Td+u+U8UBgAC7YDihJ1ZGESWfEpjaxoU="
+    access_key: git@github.com:duglin/admin-ui.git
+    # access_key:
+      # secure: "ZHw5o9aH8zL/c6iwVTv9/7STggk9IiedZh0jrw3DQqZtu6K6G04iIF+S/5EDiCIcZj+EARoZsk1TPO8v+OS0WpZoxSo2of04tWA0cfXnkc5R2hdjDIsUJxJC1/xkDwCpCuTKIvf9yh3Td+u+U8UBgAC7YDihJ1ZGESWfEpjaxoU="
 before_install:
 - git submodule update --init --recursive
 - gem install rubocop


### PR DESCRIPTION
I believe the encrypted key fails for all forked repos so reverting back to it being in plain text for now.
