### PR TITLE
Link between orgs and space tabs to service instances tab

### DIFF
--- a/lib/admin/public/js/app/adminUI.js
+++ b/lib/admin/public/js/app/adminUI.js
@@ -379,6 +379,11 @@ var AdminUI =
         AdminUI.tabs[Constants.ID__ROUTES].showRoutes(filter);
     },
 
+    showServiceInstances: function(filter)
+    {
+        AdminUI.tabs[Constants.ID__SERVICE_INSTANCES].showServiceInstances(filter);
+    },
+
     showSpace: function(target)
     {
         AdminUI.tabs[Constants.ID__SPACES].showSpace(target);

--- a/lib/admin/public/js/app/tabs/organizationsTab.js
+++ b/lib/admin/public/js/app/tabs/organizationsTab.js
@@ -423,7 +423,7 @@ OrganizationsTab.prototype.showDetails = function(table, organization, row)
     $(servicesLink).html(Format.formatNumber(row[9]));
     $(servicesLink).click(function()
     {
-        AdminUI.showApplications(Format.formatString(organization.name) + "/");
+        AdminUI.showServiceInstances(Format.formatString(organization.name) + "/");
 
         return false;
     });

--- a/lib/admin/public/js/app/tabs/serviceInstancesTab.js
+++ b/lib/admin/public/js/app/tabs/serviceInstancesTab.js
@@ -480,3 +480,32 @@ ServiceInstancesTab.prototype.displayApplicationDetail = function(event, rowInde
     return false;
 }
 
+ServiceInstancesTab.prototype.showServiceInstances = function(filter)
+{
+    AdminUI.setTabSelected(this.id);
+
+    this.hideDetails();
+    $("#ServiceInstancesApplicationsTableContainer").hide();
+
+    var applicationsDeferred     = Data.get(Constants.URL__APPLICATIONS,      false);
+    var organizationsDeferred    = Data.get(Constants.URL__ORGANIZATIONS,     false);
+    var serviceBindingsDeferred  = Data.get(Constants.URL__SERVICE_BINDINGS,  false);
+    var serviceInstancesDeferred = Data.get(Constants.URL__SERVICE_INSTANCES, false);
+    var servicePlansDeferred     = Data.get(Constants.URL__SERVICE_PLANS,     false);
+    var servicesDeferred         = Data.get(Constants.URL__SERVICES,          false);
+    var spacesDeferred           = Data.get(Constants.URL__SPACES,            false);
+
+    $.when(applicationsDeferred, organizationsDeferred, serviceBindingsDeferred, serviceInstancesDeferred, servicePlansDeferred, servicesDeferred, spacesDeferred).done($.proxy(function(applicationsResult, organizationsResult, serviceBindingsResult, serviceInstancesResult, servicePlansResult, servicesResult, spacesResult)
+    {
+        var tableData = this.getTableData([applicationsResult, organizationsResult, serviceBindingsResult, serviceInstancesResult, servicePlansResult, servicesResult, spacesResult]);
+
+        this.table.fnClearTable();
+        this.table.fnAddData(tableData);
+
+        this.table.fnFilter(filter);
+
+        this.show();
+    },
+    this));
+}
+

--- a/lib/admin/public/js/app/tabs/spacesTab.js
+++ b/lib/admin/public/js/app/tabs/spacesTab.js
@@ -408,7 +408,7 @@ SpacesTab.prototype.showDetails = function(table, target, row)
     $(servicesLink).html(Format.formatNumber(row[8]));
     $(servicesLink).click(function()
     {
-        AdminUI.showApplications(Format.formatString(row[1]));
+        AdminUI.showServiceInstances(Format.formatString(row[1]));
 
         return false;
     });

--- a/spec/integration/web/admin_spec.rb
+++ b/spec/integration/web/admin_spec.rb
@@ -152,7 +152,7 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
             check_filter_link('Organizations', 9, 'Applications', "#{ cc_organizations['resources'][0]['entity']['name'] }/")
           end
           it 'has services link' do
-            check_filter_link('Organizations', 10, 'Applications', "#{ cc_organizations['resources'][0]['entity']['name'] }/")
+            check_filter_link('Organizations', 10, 'ServiceInstances', "#{ cc_organizations['resources'][0]['entity']['name'] }/")
           end
           it 'has applications link' do
             check_filter_link('Organizations', 16, 'Applications', "#{ cc_organizations['resources'][0]['entity']['name'] }/")
@@ -239,7 +239,7 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
             check_filter_link('Spaces', 7, 'Applications', "#{ cc_organizations['resources'][0]['entity']['name'] }/#{ cc_spaces['resources'][0]['entity']['name'] }")
           end
           it 'has services link' do
-            check_filter_link('Spaces', 8, 'Applications', "#{ cc_organizations['resources'][0]['entity']['name'] }/#{ cc_spaces['resources'][0]['entity']['name'] }")
+            check_filter_link('Spaces', 8, 'ServiceInstances', "#{ cc_organizations['resources'][0]['entity']['name'] }/#{ cc_spaces['resources'][0]['entity']['name'] }")
           end
           it 'has applications link' do
             check_filter_link('Spaces', 14, 'Applications', "#{ cc_organizations['resources'][0]['entity']['name'] }/#{ cc_spaces['resources'][0]['entity']['name'] }")


### PR DESCRIPTION
We could not do this link prior to the addition of the service instances tab
