### PR TITLE
Add service plans tab

### DIFF
--- a/lib/admin/cc.rb
+++ b/lib/admin/cc.rb
@@ -62,12 +62,12 @@ module AdminUI
       end
     end
 
+    def invalidate_service_caches
+      invalidate_cache(:service_plans)
+    end
+
     def invalidate_routes
-      hash = @caches[:routes]
-      hash[:semaphore].synchronize do
-        hash[:result] = nil
-        hash[:condition].broadcast
-      end
+      invalidate_cache(:routes)
     end
 
     def routes
@@ -134,6 +134,22 @@ module AdminUI
     end
 
     private
+
+    def invalidate_cache(key, *rediscover)
+      key_string = key.to_s
+
+      hash = @caches[key]
+      hash[:semaphore].synchronize do
+        if rediscover
+          result_cache = send("discover_#{ key_string }".to_sym)
+          @logger.debug("Caching CC #{ key_string } data...")
+          hash[:result] = result_cache
+        else
+          hash[:result] = nil
+        end
+        hash[:condition].broadcast
+      end
+    end
 
     def schedule_discovery(key, hash)
       key_string = key.to_s

--- a/lib/admin/operation.rb
+++ b/lib/admin/operation.rb
@@ -25,5 +25,12 @@ module AdminUI
         @cc.invalidate_routes
       end
     end
+
+    def manage_service_plan(service_plan_guid, control_message)
+      url = "/v2/service_plans/#{ service_plan_guid}"
+      @logger.debug("#{url}, #{control_message}")
+      @client.put_cc(url, control_message)
+      @cc.invalidate_service_caches
+    end
   end
 end

--- a/lib/admin/public/application.html
+++ b/lib/admin/public/application.html
@@ -37,6 +37,7 @@
         <script src="js/app/tabs/routersTab.js"></script>
         <script src="js/app/tabs/routesTab.js"></script>
         <script src="js/app/tabs/serviceInstancesTab.js"></script>
+        <script src="js/app/tabs/servicePlansTab.js"></script>
         <script src="js/app/tabs/spacesTab.js"></script>
         <script src="js/app/tabs/statsTab.js"></script>
         <script src="js/app/tabs/tasksTab.js"></script>
@@ -123,6 +124,10 @@
 
             <span id="Gateways" class="menuItem">
                 Service Gateways
+            </span>
+
+            <span id="ServicePlans" class="menuItem">
+                Service Plans
             </span>
 
             <span id="Routers" class="menuItem">
@@ -261,6 +266,54 @@
                 </div>
 
             </div>
+
+            <div id="ServicePlansPage" class="page hiddenPage">
+
+                <div id="ServicePlansTableContainer" class="pageSection">
+
+                    <table id="ServicePlansTable" cellpadding="0" cellspacing="0" border="0" class="customTable">
+                        <thead>
+                            <tr class="customTableHeaderGroup">
+                                <th colspan="5">Service Plan</th>
+                                <th colspan="7">Service</th>
+                            </tr>
+                            <tr>
+                                <th>Check</th>
+                                <th>Name</th>
+                                <th>Created</th>
+                                <th>Public</th>
+                                <th>Service Instances</th>
+
+                                <th>Provider</th>
+                                <th>Label</th> 
+                                <th>Version</th>
+                                <th>Created</th>
+                                <th>Active</th>
+                                <th>Bindable</th>
+                                <th>Description</th>
+
+                            </tr>
+                        </thead>
+                        <tbody>
+                        </tbody>
+                    </table>
+
+                </div>
+
+                <div class="verticalPageSection">
+
+                    <div id="ServicePlansDetailsLabel" class="propertyLabel">
+                        Details
+                    </div>
+
+                    <div id="ServicePlansPropertiesContainer">
+                    </div>
+
+                </div>
+
+            </div>
+
+            </div>  
 
             <div id="RoutesPage" class="page hiddenPage">
                 <div id="RoutesTableContainer" class="pageSection">

--- a/lib/admin/public/css/application.css
+++ b/lib/admin/public/css/application.css
@@ -403,10 +403,10 @@ a
     left: 50%;
     width: 280px;
     margin-left:-140px;
-    height: 50px;
-    margin-top:-80px;
+    height: 80px;
+    margin-top:-40px;
     padding: 0;
-    border: 3px solid gray;
+    /* border: 3px solid gray; */
     background-color: #F0F5F8;
     _position:absolute;
     z-index:1011;
@@ -415,14 +415,13 @@ a
 
 .modal_dialog_div_messageshow
 {
-    height:30px;
     width:280px;
     line-height:30px;
     text-align:center;
-    margin:0 auto;
+    /* margin:0 auto; */
     color:#000;
     font-size:13px;
     font-weight:bold;
     overflow:hidden;
-    margin-top:10px;
+    /* margin-top:10px;*/
 }

--- a/lib/admin/public/js/app/adminUI.js
+++ b/lib/admin/public/js/app/adminUI.js
@@ -379,6 +379,11 @@ var AdminUI =
         AdminUI.tabs[Constants.ID__ROUTES].showRoutes(filter);
     },
 
+    showServicePlan: function(filter)
+    {
+        AdminUI.tabs[Constants.ID__SERVICE_PLANS].showServicePlan(filter);
+    },
+
     showServiceInstances: function(filter)
     {
         AdminUI.tabs[Constants.ID__SERVICE_INSTANCES].showServiceInstances(filter);

--- a/lib/admin/public/js/app/constants.js
+++ b/lib/admin/public/js/app/constants.js
@@ -14,6 +14,7 @@ var Constants =
     ID__ROUTERS:           "Routers",
     ID__ROUTES:            "Routes",
     ID__SERVICE_INSTANCES: "ServiceInstances",
+    ID__SERVICE_PLANS:     "ServicePlans",
     ID__SPACES:            "Spaces",
     ID__STATS:             "Stats",
     ID__TASKS:             "Tasks",
@@ -27,6 +28,8 @@ var Constants =
     STATUS__STAGED:   "STAGED",
     STATUS__STARTED:  "STARTED",
     STATUS__STOPPED:  "STOPPED",
+    STATUS__PRIVATE:  "private",
+    STATUS__PUBLIC:   "public",
 
     URL__APPLICATIONS:      "applications",
     URL__CLOUD_CONTROLLERS: "cloud_controllers",
@@ -51,6 +54,6 @@ var Constants =
     URL__STATS:             "statistics",
     URL__TASK_STATUS:       "task_status",
     URL__TASKS:             "tasks",
-    URL__USERS:             "users"
+    URL__USERS:             "users",
 }
 

--- a/lib/admin/public/js/app/format.js
+++ b/lib/admin/public/js/app/format.js
@@ -419,6 +419,24 @@ var Format =
         return (value != null) ? value : "";
     },
 
+    formatIconImage: function(url)
+    {
+        if (! url) 
+        {
+           return "";
+        }
+        var html = "<div  style='{2}'><img class='icon-image' src='{0}' alt='{1}'></div>";
+        var altText = (arguments.length >= 2) ? arguments[1]: '';
+        var style   = (arguments.length >= 3) ? arguments[2]: '';
+        html = Utilities.localize(html, [url, altText, style]);
+        return html;
+    },
+
+    formatBoolean: function(value)
+    {
+        return (value) ? "true" : "false";
+    },
+
     formatTarget: function(name, type, item)
     {
         return Format.formatTruncatedString(name, type, item, 30);

--- a/lib/admin/public/js/app/tab.js
+++ b/lib/admin/public/js/app/tab.js
@@ -209,6 +209,14 @@ Tab.prototype.addJSONDetailsLinkRow = function(table, key, value, json, first)
     this.addRow(table, key, details, first);
 }
 
+Tab.prototype.addFormattableTextRow = function(table, key, value, json, first)
+{
+    var details = document.createElement("div");
+    details.innerHTML = value;
+
+    this.addRow(table, key, details, first);
+}
+
 Tab.prototype.addLinkRow = function(table, key, value, first)
 {
     var link = document.createElement("a");

--- a/lib/admin/public/js/app/tabs/serviceInstancesTab.js
+++ b/lib/admin/public/js/app/tabs/serviceInstancesTab.js
@@ -384,7 +384,18 @@ ServiceInstancesTab.prototype.clickHandler = function()
 
         if (servicePlan != null)
         {
-            this.addPropertyRow(table, "Service Plan Name", Format.formatString(servicePlan.name));
+            var servicePlanLink = document.createElement("a");
+            $(servicePlanLink).attr("href", "");
+            $(servicePlanLink).addClass("tableLink");
+            $(servicePlanLink).html(Format.formatString(servicePlan.name));
+            $(servicePlanLink).click(function()
+            {
+                AdminUI.showServicePlan(row[4]);
+
+                return false;
+            });
+            this.addRow(table, "Service Plan Name", servicePlanLink);
+
             this.addPropertyRow(table, "Service Plan Created", Format.formatDateString(servicePlan.created_at));
             this.addPropertyRow(table, "Service Plan Public", Format.formatString(servicePlan.public));
             this.addPropertyRow(table, "Service Plan Description", Format.formatString(servicePlan.description));

--- a/lib/admin/public/js/app/tabs/servicePlansTab.js
+++ b/lib/admin/public/js/app/tabs/servicePlansTab.js
@@ -1,0 +1,417 @@
+function ServicePlansTab(id) 
+{
+    this.url = Constants.URL__SERVICE_PLANS;
+    Tab.call(this, id);
+}
+
+ServicePlansTab.prototype             = new Tab();
+
+ServicePlansTab.prototype.constructor = ServicePlansTab;
+
+ServicePlansTab.prototype.initialize = function() 
+{
+    this.table = Table.createTable(
+        this.id,
+        this.getColumns(),
+        this.getInitialSort(),
+        $.proxy(this.clickHandler, this),
+        [
+            {
+                text : " Public ",
+                click : $.proxy(function() 
+                {
+                    this.changeVisibilit("public")
+                }, this)
+            },
+            {
+                text : "Private",
+                click : $.proxy(function() 
+                {
+                    this.changeVisibilit("private")
+                }, this)
+            }
+        ]);
+}
+
+ServicePlansTab.prototype.getInitialSort = function() 
+{
+    return [[0, "asc"]];
+}
+
+//Create enumeration only when it is necessary.
+ServicePlansTab.ENUM_SERVICE_PLANE_CHECKBOX = 0;
+ServicePlansTab.ENUM_SERVICE_PLANE_NAME     = 1;
+ServicePlansTab.ENUM_SERVICE_PLANE_PUBLIC   = 3;
+ServicePlansTab.ENUM_ADDON                  = 12;
+
+ServicePlansTab.prototype.getColumns = function() 
+{
+    return [
+                {
+                    "sTitle" : "",
+                    "sClass" : "cellCenterAlign",
+                    "bSortable" : false,
+                    "mRender" : function(value, type) 
+                    {
+                        return '<input type="checkbox" value="' + value + '" onclick="ServicePlansTab.prototype.checkboxClickHandler(event)"></input>';
+                    }
+                },
+                {
+                    "sTitle" : "Name",
+                    "sWidth" : "200px",
+                    "mRender" : Format.formatServiceString
+                },
+                {
+                    "sTitle" : "Created",
+                    "sWidth" : "170px",
+                    "mRender" : Format.formatDateString
+                },
+                {
+                    "sTitle" : "Public",
+                    "sWidth" : "70px"
+                },
+                {
+                    "sTitle" : "Service Instances",
+                    "sWidth" : "80px",
+                    "mRender" : Format.FormatNumber
+                },
+                {
+                    "sTitle" : "Provider",
+                    "sWidth" : "100px",
+                    "mRender" : Format.formatServiceString
+                },
+                {
+                       "sTitle":  "Label",
+                       "sWidth":  "200px",
+                       "mRender": Format.formatServiceString
+                },
+                {
+                    "sTitle" : "Version",
+                    "sWidth" : "100px",
+                    "mRender" : Format.formatServiceString
+                },
+                {
+                    "sTitle" : "Created",
+                    "sWidth" : "170px",
+                    "mRender" : Format.formatDateString
+                },
+                {
+                    "sTitle" : "Active",
+                    "sWidth" : "80px"
+                },
+                {
+                    "sTitle" : "Bindable",
+                    "sWidth" : "80px"
+                },
+                {
+                    "sTitle" : "Description",
+                    "sWidth" : "200px"
+                }
+            ];
+}
+
+ServicePlansTab.prototype.linkClickHandler = function(service_plan_name) 
+{
+    AdminUI.showServiceInstances(service_plan_name);
+}
+
+ServicePlansTab.prototype.refresh = function(reload) 
+{
+    var servicePlansDeferred     = Data.get(Constants.URL__SERVICE_PLANS, reload);
+    var servicesDeferred         = Data.get(Constants.URL__SERVICES, reload);
+    var serviceInstancesDeferred = Data.get(Constants.URL__SERVICE_INSTANCES, reload);
+    
+    $.when(servicePlansDeferred, servicesDeferred, serviceInstancesDeferred).done(
+        $.proxy(function(servicePlansResult, servicesResult, serviceInstancesResult) 
+        {
+            this.updateData([servicePlansResult, servicesResult, serviceInstancesResult], reload);
+            this.table.fnDraw();
+        }, this));
+}
+
+ServicePlansTab.prototype.getTableData = function(results) 
+{
+    var servicePlans     = results[0].response.items;
+    var services         = results[1].response.items;
+    var serviceInstances = results[2].response.items;
+
+    var serviceMap = [];
+
+    for (var serviceIndex in services)
+    {
+        var service              = services[serviceIndex];
+        serviceMap[service.guid] = service;
+    }
+
+    var servicePlanMap = [];
+
+    for (var servicePlanIndex in servicePlans)
+    {
+        var servicePlan                     = servicePlans[servicePlanIndex];
+        servicePlan.service_instances_count = 0;  //initialize service instances count per service plan to zero
+        servicePlanMap[servicePlan.guid]    = servicePlan;
+    }
+    
+    //count the service service instance per service_plan
+    for (var serviceInstanceIndex in serviceInstances)
+    {
+        var serviceInstance = serviceInstances[serviceInstanceIndex];
+        var servicePlan     = servicePlanMap[serviceInstance.service_plan_guid];
+
+        if (servicePlan != null)
+        {
+            servicePlan.service_instances_count += 1;  
+        }
+    }
+    
+    //populate table with data
+    
+    var tableData = [];
+    for (var servicePlanIndex in servicePlans)
+    {
+        var servicePlan = servicePlans[servicePlanIndex];
+        var service     = (servicePlan == null) ? null : serviceMap[servicePlan.service_guid];
+        var row         = [];
+        var addon       = {};
+
+        if (servicePlan != null)
+        {
+            row.push(servicePlan.guid);
+            row.push(servicePlan.name);
+            row.push(servicePlan.created_at);
+            row.push(servicePlan.public);
+            row.push(servicePlan.service_instances_count);
+            addon.service_plan = servicePlan;
+        }
+        else
+        {
+            Utilities.addEmptyElementsToArray(row, 5);
+        }
+
+        if (service != null)
+        {
+            row.push(service.provider);
+            row.push(service.label);
+            row.push(service.version);
+            row.push(service.created_at);
+            row.push(service.active);
+            row.push(service.bindable);
+            row.push(service.description);
+            addon.service = service;
+        }
+        else
+        {
+            Utilities.addEmptyElementsToArray(row, 7);
+        }
+
+        row.push(addon);
+        tableData.push(row);
+    }
+
+    return tableData;
+}
+
+ServicePlansTab.prototype.clickHandler = function(event) 
+{
+    var tableTools = TableTools.fnGetInstance("ServicePlansTable");
+    var selected   = tableTools.fnGetSelectedData();
+
+    this.hideDetails();
+
+    if (selected.length > 0)
+    {
+        $("#ServicePlansDetailsLabel").show();
+
+        var containerDiv = $("#ServicePlansPropertiesContainer").get(0);
+        var table        = this.createPropertyTable(containerDiv);
+        var row          = selected[0];
+        var target       = row[ServicePlansTab.ENUM_ADDON];
+        var service      = target.service;
+        var servicePlan  = target.service_plan;
+
+        if (servicePlan != null)
+        {
+            //create a link
+            var serviceInstancesink = document.createElement("a");
+            $(serviceInstancesink).attr("href", "");
+            $(serviceInstancesink).addClass("tableLink");
+            $(serviceInstancesink).html(Format.formatNumber(servicePlan.service_instances_count));
+            $(serviceInstancesink).click(function()
+            {
+                AdminUI.showServiceInstances(row[4]);
+
+                return false;
+            });
+
+            this.addPropertyRow(table, "Service Plan Name",                Format.formatString(servicePlan.name));
+            this.addPropertyRow(table, "Service Plan Created",             Format.formatDate(servicePlan.created_at));
+            this.addPropertyRow(table, "Service Plan Public",              Format.formatBoolean(servicePlan.public));
+            this.addRow(        table, "Service Instances",                serviceInstancesink);
+            this.addPropertyRow(table, "Service Plan GUID",                Format.formatString(servicePlan.guid));
+        }
+
+        if (service != null)
+        {
+            this.addPropertyRow(table, "Service Provider",                 Format.formatString(service.provider));
+            this.addPropertyRow(table, "Service Label",                    Format.formatString(service.label));
+            this.addPropertyRow(table, "Service Version",                  Format.formatString(service.version));
+            this.addPropertyRow(table, "Service Created",                  Format.formatDate(service.created_at));
+            this.addPropertyRow(table, "Service Active",                   Format.formatBoolean(service.active));
+            this.addPropertyRow(table, "Service Bindable",                 Format.formatString(service.bindable));
+            this.addPropertyRow(table, "Service Description",              Format.formatString(service.description));
+            
+            if (service.extra != null)
+            {
+                var serviceExtra = jQuery.parseJSON(service.extra);
+                this.addPropertyRow(table, "Service Display Name",         Format.formatString(serviceExtra.displayName));
+                this.addPropertyRow(table, "Service Provider Display Name",Format.formatString(serviceExtra.providerDisplayName));
+                this.addFormattableTextRow(table, "Service Icon",          Format.formatIconImage(serviceExtra.imageUrl, "service icon", "flot:left;"));
+                this.addPropertyRow(table, "Service Long Description",     Format.formatString(serviceExtra.longDescription));
+            }
+        }
+    }
+}
+
+ServicePlansTab.prototype.checkboxClickHandler = function(event)
+{
+    event.stopPropagation();
+}
+
+ServicePlansTab.prototype.changeVisibilit = function(targetdVisibility) 
+{
+
+    if (!targetdVisibility || 
+        (targetdVisibility != Constants.STATUS__PUBLIC && 
+         targetdVisibility != Constants.STATUS__PRIVATE ) ) 
+    {
+        return;
+    }
+
+    var rows = this.getSelectedRowsOfMainTable();
+
+    if (!rows || rows.length == 0) 
+    {
+        return;  //quit when there is nothing picked.
+    }
+
+    var message = Utilities.localize("You are about to make selected service plans {0}.  Do you want to continue?", [ targetdVisibility ]);
+
+    if (!confirm(message) ) 
+    {
+        return;  //cancel
+    }
+    AdminUI.showModalDialog("<div  style=z-index:10;background-color:#FFFFFF;padding-top:12px;height:80px;line-height:24px;'><center><img class='icon-image' src='../../../../images/loading.gif' alt='Updating...' /><center><span>Update is in progress...</span></div>");
+
+    var error_servicePlans = [];
+    var isPlanChanged      = false;
+    for (var rowIdx = 0, rowCount = rows.length; rowIdx < rowCount; rowIdx++) 
+    {
+        var row = rows[rowIdx];
+        var isPlanPublic = row[ServicePlansTab.ENUM_SERVICE_PLANE_PUBLIC];
+        if (isPlanPublic == (targetdVisibility === Constants.STATUS__PUBLIC) ) 
+        {
+            continue;
+        }
+        var url = "/service_plans/" + row[ServicePlansTab.ENUM_SERVICE_PLANE_CHECKBOX]; ;
+        var servicePlanGUID = row[ServicePlansTab.ENUM_SERVICE_PLANE_CHECKBOX];
+        var body = (targetdVisibility === Constants.STATUS__PUBLIC) ? '{"public": true}': '{"public": false }';
+        
+        $.ajax(
+        {
+            type: 'PUT',
+            async : false,
+            url : url,
+            contentType : "application/json; charset=utf-8",
+            dataType : "json",
+            data: body,
+            success : function(data) 
+            {
+                var servicePlanName = row[ServicePlansTab.ENUM_SERVICE_PLANE_NAME];
+                console.log(Utilities.localize("Service plan {0} is changed to {1}.", [ servicePlanName, targetdVisibility ]));
+                isPlanChanged = true;
+                AdminUI.refresh();
+            },
+            error : function(msg) 
+            {
+                var servicePlanName = row[ServicePlansTab.ENUM_SERVICE_PLANE_NAME];
+                error_servicePlans.push(servicePlanName);
+            }
+        });
+    }
+
+    AdminUI.closeModalDialog();
+
+    if (isPlanChanged)
+    {
+        alert("Update on service plans was completed successfully.");
+    }
+    if (error_servicePlans.length > 0) 
+    {
+        alert( Utilities.localizeSequence("Update on the following service plans encountered problems: {n}.", ", ", error_servicePlans));
+    } 
+}
+
+ServicePlansTab.prototype.getSelectedRowsOfMainTable = function() 
+{
+    var checkedRows = $("input:checked", this.table.fnGetNodes());
+
+    if (checkedRows.length == 0)
+    {
+        alert("Please select at least one row!");
+        return null;
+    }
+
+    var selectedRows = [];
+
+    var servicePlansDeferred = Data.get(Constants.URL__SERVICE_PLANS, false);
+    var servicesDeferred = Data.get(Constants.URL__SERVICES, false);
+    var serviceInstancesDeferred = Data.get(Constants.URL__SERVICE_INSTANCES, false);
+
+    $.when(servicePlansDeferred, servicesDeferred, serviceInstancesDeferred).done(
+        $.proxy(function(servicePlansResult, servicesResult, serviceInstancesResult) 
+        {
+            var tableData = this.getTableData([servicePlansResult, servicesResult, serviceInstancesResult]);
+            for (var rowIdx = 0, rowCount = tableData.length; rowIdx < rowCount; rowIdx++) 
+            {
+                var row = tableData[rowIdx];
+                for (var checkRowIdx = 0; checkRowIdx < checkedRows.length; checkRowIdx++) 
+                {
+                    var selectedValue = checkedRows[checkRowIdx].value;
+                    if (selectedValue && selectedValue === row[ServicePlansTab.ENUM_SERVICE_PLANE_CHECKBOX] ) 
+                    { 
+                        selectedRows.push(row);
+                    }
+                }
+            } 
+        }, this));
+    return selectedRows;
+}
+
+ServicePlansTab.prototype.showServicePlan = function(filter) 
+{
+
+    AdminUI.setTabSelected(this.id);
+    // Several calls in this function trigger a saveTableScrollPosition() which corrupts the scroll position.
+    Table.ignoreScroll = true;
+
+    // Save and clear the sorting so we can select by index.
+    var sorting = this.table.fnSettings().aaSorting;
+    this.table.fnSort([]);
+
+    var servicePlansDeferred     = Data.get(Constants.URL__SERVICE_PLANS, false);
+    var servicesDeferred         = Data.get(Constants.URL__SERVICES, false);
+    var serviceInstancesDeferred = Data.get(Constants.URL__SERVICE_INSTANCES, false);
+
+    $.when(servicePlansDeferred, servicesDeferred, serviceInstancesDeferred).done(
+        $.proxy(function(servicePlansResult, servicesResult, serviceInstancesResult) 
+        {
+            var tableData = this.getTableData([servicePlansResult, servicesResult, serviceInstancesResult]);
+            this.table.fnClearTable();
+            this.table.fnAddData(tableData);
+            this.table.fnFilter(filter);
+            this.show();
+
+        }, 
+        this));
+
+} 

--- a/lib/admin/public/js/app/utilities.js
+++ b/lib/admin/public/js/app/utilities.js
@@ -34,6 +34,40 @@ var Utilities =
         while (numberString.length < size) numberString = "0" + numberString;
 
         return numberString;
-    }
+    },
+
+    localize: function (message, params) 
+    {
+        var locMessage = message;
+        for (var i = 0, count = params.length; i < count; i++) 
+        {
+            var param = params[i];
+            if (param == null) 
+            {
+                break;
+            }
+            var varSymbol = "{" + i + "}";
+            locMessage    = locMessage.replace(varSymbol, params[i]);
+        }
+        return locMessage;
+    },
+
+    localizeSequence: function(message, separator, params)
+    {
+        var locMessage      = message;
+        var sequenceString  = params[0];
+        for (var i = 1, count = params.length; i < count; i++)
+        {
+            var param = params[i];
+            if (param == null) 
+            {
+                break;
+            }
+            sequenceString += separator + param;
+        }
+        var varSymbol = "{n}";
+        locMessage    = locMessage.replace(varSymbol, sequenceString);
+        return locMessage;
+    },
 };
 

--- a/lib/admin/web.rb
+++ b/lib/admin/web.rb
@@ -219,6 +219,20 @@ module AdminUI
       end
     end
 
+    put '/service_plans/:service_plan_guid', :auth => [:admin] do
+      begin
+        control_message = request.body.read.to_s
+        service_plan_guid = params[:service_plan_guid]
+        @operation.manage_service_plan(service_plan_guid, control_message)
+
+        204
+      rescue => error
+        @logger.debug("Error during update to service plan #{ error.inspect }")
+        @logger.debug(error.backtrace.join("\n"))
+        500
+      end
+    end
+
     delete '/components', :auth => [:user] do
       @varz.remove(params['uri'])
 

--- a/spec/integration/admin_spec.rb
+++ b/spec/integration/admin_spec.rb
@@ -117,6 +117,32 @@ describe AdminUI::Admin, :type => :integration do
     end
   end
 
+  context 'manage service plan' do
+    let(:http)   { create_http }
+    let(:cookie) { login_and_return_cookie(http) }
+
+    before do
+      # Make sure the original service plan status is public
+      expect(get_json('/service_plans')['items'][0]['public'].to_s).to eq('true')
+    end
+
+    def make_service_plan_private
+      response = put_request('/service_plans/service_plan1', '{"public": false }')
+      expect(response.is_a? Net::HTTPNoContent).to be_true
+    end
+
+    def make_service_plan_public
+      response = put_request('/service_plans/service_plan1', '{"public": true }')
+      expect(response.is_a? Net::HTTPNoContent).to be_true
+    end
+
+    it 'make service plans private' do
+      # Stub the http request to return
+      cc_service_plans_public_to_private_stub(AdminUI::Config.load(config))
+      expect { make_service_plan_private }.to change { get_json('/service_plans')['items'][0]['public'].to_s }.from('true').to('false')
+    end
+  end
+
   context 'retrieves and validates' do
     let(:http)   { create_http }
     let(:cookie) { login_and_return_cookie(http) }

--- a/spec/integration/cc_spec.rb
+++ b/spec/integration/cc_spec.rb
@@ -41,6 +41,11 @@ describe AdminUI::CC, :type => :integration do
       expect { cc.invalidate_routes }.to change { cc.routes['items'].length }.from(1).to(0)
     end
 
+    it 'refresh the service plan cache' do
+      cc_service_plans_public_to_private_stub(config)
+      expect { cc.invalidate_service_caches }.to change { cc.service_plans['items'][0]['public'].to_s }.from('true').to('false')
+    end
+
     it 'returns connected applications' do
       applications = cc.applications
 

--- a/spec/integration/operation_spec.rb
+++ b/spec/integration/operation_spec.rb
@@ -71,5 +71,18 @@ describe AdminUI::Operation, :type => :integration do
         expect { operation.manage_route('DELETE', 'route1') }.to change { cc.routes['items'].length }.from(1).to(0)
       end
     end
+
+    context 'manage service plan' do
+      before do
+        # Make sure the original service plan's public field is true
+        expect(cc.service_plans['items'][0]['public'].to_s).to eq('true')
+      end
+
+      it 'makes service plan private' do
+        # Mock the http response for private service plan
+        cc_service_plans_private_stub(config)
+        expect { operation.manage_service_plan('service_plan1', '{"public": false }') }.to change { cc.service_plans['items'][0]['public'].to_s }.from('true').to('false')
+      end
+    end
   end
 end

--- a/spec/integration/web/admin_spec.rb
+++ b/spec/integration/web/admin_spec.rb
@@ -34,6 +34,7 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
       expect(@driver.find_element(:id => 'CloudControllers').displayed?).to be_true
       expect(@driver.find_element(:id => 'HealthManagers').displayed?).to be_true
       expect(@driver.find_element(:id => 'Gateways').displayed?).to be_true
+      expect(@driver.find_element(:id => 'ServicePlans').displayed?).to be_true
       expect(@driver.find_element(:id => 'Routers').displayed?).to be_true
       expect(@driver.find_element(:id => 'Routes').displayed?).to be_true
       expect(@driver.find_element(:id => 'Components').displayed?).to be_true
@@ -600,11 +601,158 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
                                @driver.execute_script("return Format.formatDateString(\"#{ cc_service_bindings['resources'][0]['metadata']['created_at'] }\")")
                              ])
           end
+          it 'has service plan name link' do
+            check_filter_link('ServiceInstances', 14, 'ServicePlans', cc_service_plans['resources'][0]['entity']['name'])
+          end
           it 'has space link' do
             check_select_link('ServiceInstances', 19, 'Spaces', cc_spaces['resources'][0]['entity']['name'])
           end
           it 'has organization link' do
             check_select_link('ServiceInstances', 20, 'Organizations', cc_organizations['resources'][0]['entity']['name'])
+          end
+        end
+      end
+
+      context 'Service Plans' do
+        let(:tab_id) { 'ServicePlans' }
+        it 'has a table' do
+          check_table_layout([{ :columns         => @driver.find_elements(:xpath => "//div[@id='ServicePlansTable_wrapper']/div[5]/div[1]/div/table/thead/tr[1]/th"),
+                                :expected_length => 2,
+                                :labels          => ['Service Plan', 'Service'],
+                                :colspans        => %w(5 7)
+                              },
+                              {
+                                :columns         => @driver.find_elements(:xpath => "//div[@id='ServicePlansTable_wrapper']/div[5]/div[1]/div/table/thead/tr[2]/th"),
+                                :expected_length => 12,
+                                :labels          => ['', 'Name', 'Created', 'Public', 'Service Instances', 'Provider', 'Label', 'Version', 'Created', 'Active', 'Bindable', 'Description'],
+                                :colspans        => nil
+                              }
+                             ])
+          check_table_data(@driver.find_elements(:xpath => "//table[@id='ServicePlansTable']/tbody/tr/td"),
+                           [
+                             '',
+                             cc_service_plans['resources'][0]['entity']['name'],
+                             @driver.execute_script("return Format.formatDateString(\"#{ cc_service_plans['resources'][0]['metadata']['created_at'] }\")"),
+                             cc_service_plans['resources'][0]['entity']['public'].to_s,
+                             cc_service_instances['resources'].length.to_s,
+                             cc_services['resources'][0]['entity']['provider'],
+                             cc_services['resources'][0]['entity']['label'],
+                             cc_services['resources'][0]['entity']['version'],
+                             @driver.execute_script("return Format.formatDateString(\"#{ cc_services['resources'][0]['metadata']['created_at'] }\")"),
+                             cc_services['resources'][0]['entity']['active'].to_s,
+                             cc_services['resources'][0]['entity']['bindable'].to_s,
+                             cc_services['resources'][0]['entity']['description']
+                           ])
+        end
+
+        context 'selectable' do
+          before do
+            select_first_row
+          end
+
+          it 'has details' do
+            value_extra_json = JSON.parse(cc_services['resources'][0]['entity']['extra'])
+            check_details([{ :label => 'Service Plan Name',              :tag =>   nil, :value => cc_service_plans['resources'][0]['entity']['name'] },
+                           { :label => 'Service Plan Created',           :tag =>   nil, :value => @driver.execute_script("return Format.formatDateString(\"#{ cc_service_plans['resources'][0]['metadata']['created_at'] }\")") },
+                           { :label => 'Service Plan Public',            :tag =>   nil, :value => cc_service_plans['resources'][0]['entity']['public'].to_s },
+                           { :label => 'Service Instances',              :tag =>   nil, :value => cc_service_instances['resources'].length.to_s },
+                           { :label => 'Service Plan GUID',              :tag =>   nil, :value => cc_service_plans['resources'][0]['metadata']['guid'] },
+                           { :label => 'Service Provider',               :tag =>   nil, :value => cc_services['resources'][0]['entity']['provider'] },
+                           { :label => 'Service Label',                  :tag =>   nil, :value => cc_services['resources'][0]['entity']['label'] },
+                           { :label => 'Service Version',                :tag =>   nil, :value => cc_services['resources'][0]['entity']['version'] },
+                           { :label => 'Service Created',                :tag =>   nil, :value => @driver.execute_script("return Format.formatDateString(\"#{ cc_services['resources'][0]['metadata']['created_at'] }\")") },
+                           { :label => 'Service Active',                 :tag =>   nil, :value => cc_services['resources'][0]['entity']['active'].to_s },
+                           { :label => 'Service Bindable',               :tag =>   nil, :value => cc_services['resources'][0]['entity']['bindable'].to_s },
+                           { :label => 'Service Description',            :tag =>   nil, :value => cc_services['resources'][0]['entity']['description'] },
+                           { :label => 'Service Display Name',           :tag =>   nil, :value => value_extra_json['displayName'] },
+                           { :label => 'Service Provider Display Name',  :tag =>   nil, :value => value_extra_json['providerDisplayName'] },
+                           { :label => 'Service Icon',                   :tag => 'img', :value => @driver.execute_script("return Format.formatIconImage(\"#{value_extra_json['imageUrl']}\", \"service icon\", \"flot:left;\")").gsub(/'/, "\"").gsub(/[ ]+/, ' ').gsub(/ >/, '>') },
+                           { :label => 'Service Long Description',       :tag =>   nil, :value => value_extra_json['longDescription'] }
+                          ])
+          end
+
+          it 'has a checkbox in the first column' do
+            inputs = @driver.find_elements(:xpath => "//table[@id='ServicePlansTable']/tbody/tr/td[1]/input")
+            expect(inputs.length).to eq(1)
+            expect(inputs[0].attribute('value')).to eq("#{ cc_service_plans['resources'][0]['metadata']['guid'] }")
+          end
+
+          it 'has service instances link' do
+            check_filter_link('ServicePlans', 3, 'ServiceInstances', cc_service_instances['resources'].length.to_s)
+          end
+
+          context 'manage serice plans' do
+            before do
+              operation_stub(AdminUI::Config.load(config))
+            end
+
+            def check_first_row
+              @driver.find_elements(:xpath => "//table[@id='ServicePlansTable']/tbody/tr/td[1]/input")[0].click
+            end
+
+            def manage_service_plan(buttonIndex)
+              check_first_row
+              @driver.find_element(:id => "ToolTables_ServicePlansTable_#{buttonIndex}").click
+              if buttonIndex == 0
+                check_operation_result('public')
+              else
+                check_operation_result('private')
+              end
+            end
+
+            def check_service_plan_state(expect_state)
+              # As the UI table will be refreshed and recreated, add a try-catch block in case the selenium stale element
+              # error happens.
+              begin
+                Selenium::WebDriver::Wait.new(:timeout => 20).until { @driver.find_element(:xpath => "//table[@id='ServicePlansTable']/tbody/tr/td[4]").text == expect_state }
+              rescue Selenium::WebDriver::Error::TimeOutError, Selenium::WebDriver::Error::StaleElementReferenceError
+              end
+              expect(@driver.find_element(:xpath => "//table[@id='ServicePlansTable']/tbody/tr/td[4]").text).to eq(expect_state)
+            end
+
+            def check_operation_result(visibility)
+              confirm = @driver.switch_to.alert
+              expect(confirm.text).to eq("You are about to make selected service plans #{visibility}.  Do you want to continue?")
+              confirm.accept
+
+              alert = nil
+              Selenium::WebDriver::Wait.new(:timeout => 100).until { alert = @driver.switch_to.alert }
+              expect(alert.text).to eq('Update on service plans was completed successfully.')
+              alert.dismiss
+            end
+
+            it 'has a Public button' do
+              expect(@driver.find_element(:id => 'ToolTables_ServicePlansTable_0').text).to eq('Public')
+            end
+
+            it 'has a Private button' do
+              expect(@driver.find_element(:id => 'ToolTables_ServicePlansTable_1').text).to eq('Private')
+            end
+
+            shared_examples 'click public or private button without selecting a single row' do
+              it 'alerts the user to select at least one row when clicking the button' do
+                @driver.find_element(:id => buttonId).click
+                alert = @driver.switch_to.alert
+                expect(alert.text).to eq('Please select at least one row!')
+                alert.dismiss
+              end
+            end
+
+            it_behaves_like('click public or private button without selecting a single row') do
+              let(:buttonId) { 'ToolTables_ServicePlansTable_0' }
+            end
+
+            it_behaves_like('click public or private button without selecting a single row') do
+              let(:buttonId) { 'ToolTables_ServicePlansTable_1' }
+            end
+
+            it 'make selected public service plans private and back to public' do
+              check_service_plan_state('true')
+              cc_service_plans_private_stub(AdminUI::Config.load(config))
+              check_service_plan_state('true')
+              manage_service_plan(1)
+              check_service_plan_state('false')
+            end
           end
         end
       end

--- a/spec/integration/web/user_spec.rb
+++ b/spec/integration/web/user_spec.rb
@@ -76,6 +76,27 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
       expect(@driver.find_element(:id => 'ToolTables_DEAsTable_0').text).to eq('Copy')
     end
 
+    it 'does not have public and private service plan buttons' do
+      begin
+        Selenium::WebDriver::Wait.new(:timeout => 5).until do
+          @driver.find_element(:id => 'ServicePlans').click
+          @driver.find_element(:class_name => 'menuItemSelected').attribute('id') == 'ServicePlans'
+        end
+      rescue Selenium::WebDriver::Error::TimeOutError
+      end
+      expect(@driver.find_element(:class_name => 'menuItemSelected').attribute('id')).to eq('ServicePlans')
+
+      begin
+        Selenium::WebDriver::Wait.new(:timeout => 10).until do
+          @driver.find_element(:id => 'ServicePlansPage').displayed? &&
+          @driver.find_element(:id => 'ToolTables_ServicePlansTable_0').text == 'Copy'
+        end
+      rescue Selenium::WebDriver::Error::TimeOutError
+      end
+      expect(@driver.find_element(:id => 'ServicePlansPage').displayed?).to eq(true)
+      expect(@driver.find_element(:id => 'ToolTables_ServicePlansTable_0').text).to eq('Copy')
+    end
+
     it 'does not have a remove all components button' do
       begin
         Selenium::WebDriver::Wait.new(:timeout => 5).until do

--- a/spec/support/cc_helper.rb
+++ b/spec/support/cc_helper.rb
@@ -15,6 +15,7 @@ module CCHelper
   end
 
   def cc_stub(config)
+    AdminUI::Utils.stub(:http_request).and_return(nil)
     AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/info", AdminUI::Utils::HTTP_GET) do
       OK.new(cc_info)
     end
@@ -87,6 +88,36 @@ module CCHelper
   # Mock empty routes array http response.
   def cc_empty_routes_stub(config)
     AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/routes?inline-relations-depth=1", AdminUI::Utils::HTTP_GET, anything, anything, anything).and_return(CCHelper::OK.new(cc_empty_routes))
+  end
+
+  # Continuously mock two http request returns, the first http call returns applications in public state, while the second http call returns service _plans in private state, and the third one to return public service plan.
+  def cc_service_plans_public_to_private_to_public_stub(config)
+    AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/service_plans", AdminUI::Utils::HTTP_GET, anything, anything, anything).and_return(CCHelper::OK.new(cc_public_service_plans), CCHelper::OK.new(cc_private_service_plans), CCHelper::OK.new(cc_public_service_plans))
+  end
+
+  # Continuously mock two http request returns, the first http call returns applications in private state, while the second http call returns service _plans in public state, and the third one to return private service plan.
+  def cc_service_plans_private_to_public_to_private_stub(config)
+    AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/service_plans", AdminUI::Utils::HTTP_GET, anything, anything, anything).and_return(CCHelper::OK.new(cc_private_service_plans), CCHelper::OK.new(cc_public_service_plans), CCHelper::OK.new(cc_private_service_plans))
+  end
+
+  # Continuously mock two http request returns, the first http call returns applications in public state, while the second http call returns service _plans in private state.
+  def cc_service_plans_public_to_private_stub(config)
+    AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/service_plans", AdminUI::Utils::HTTP_GET, anything, anything, anything).and_return(CCHelper::OK.new(cc_public_service_plans), CCHelper::OK.new(cc_private_service_plans), CCHelper::OK.new(cc_private_service_plans))
+  end
+
+  # Continuously mock two http request returns, the first http call returns applications in private state, while the second http call returns service _plans in public state.
+  def cc_service_plans_private_to_public_stub(config)
+    AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/service_plans", AdminUI::Utils::HTTP_GET, anything, anything, anything).and_return(CCHelper::OK.new(cc_private_service_plans), CCHelper::OK.new(cc_public_service_plans))
+  end
+
+  # Continuously mock two http request returns, the first http call returns applications in public state, while the second http call returns service _plans in private state.
+  def cc_service_plans_public_stub(config)
+    AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/service_plans", AdminUI::Utils::HTTP_GET, anything, anything, anything).and_return(CCHelper::OK.new(cc_public_service_plans))
+  end
+
+  # Continuously mock two http request returns, the first http call returns applications in private state, while the second http call returns service _plans in public state.
+  def cc_service_plans_private_stub(config)
+    AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/service_plans", AdminUI::Utils::HTTP_GET, anything, anything, anything).and_return(CCHelper::OK.new(cc_private_service_plans))
   end
 
   def cc_empty_routes
@@ -197,10 +228,11 @@ module CCHelper
           },
           'entity'   =>
           {
+            'active'            => true,
             'bindable'          => true,
             'description'       => 'TestService description',
             'documentation_url' => 'http://documentation_url.com',
-            'extra'             => 'service extra',
+            'extra'             => '{"displayName":"displayname","imageUrl":"http://docs.cloudfoundry.com/images/favicon.ico","longDescription":"long description","providerDisplayName":"provider name"}',
             'info_url'          => 'http://info_url.com',
             'label'             => 'TestService',
             'provider'          => 'test',
@@ -400,6 +432,60 @@ module CCHelper
               }
           }
         ]
+    }
+  end
+
+# Mock the http response of a batch of applications in public state.
+  def cc_public_service_plans
+    {
+      'total_results' => 1,
+      'resources'     =>
+      [
+        {
+          'metadata' =>
+          {
+            'created_at' => '2014-02-12T09:34:10-06:00',
+            'guid'       => 'service_plan1'
+          },
+          'entity'   =>
+          {
+            'description'  => 'TestServicePlan description',
+            'extra'        => 'service plan extra',
+            'free'         => true,
+            'name'         => 'TestServicePlan',
+            'public'       => true,
+            'service_guid' => 'service1',
+            'unique_id'    => 'service_plan_unique_id1'
+          }
+        }
+      ]
+    }
+  end
+
+# Mock the http response of a batch of applications in public state.
+  def cc_private_service_plans
+    {
+      'total_results' => 1,
+      'resources'     =>
+      [
+        {
+          'metadata' =>
+          {
+            'created_at' => '2014-02-12T09:34:10-06:00',
+            'guid'       => 'service_plan1'
+          },
+          'entity'   =>
+          {
+            'description'  => 'TestServicePlan description',
+            'extra'        => 'service plan extra',
+            'free'         => true,
+            'name'         => 'TestServicePlan',
+            'public'       => false,
+            'service_guid' => 'service1',
+            'unique_id'    => 'service_plan_unique_id1'
+          }
+        }
+      ]
     }
   end
 

--- a/spec/support/operation_helper.rb
+++ b/spec/support/operation_helper.rb
@@ -25,5 +25,13 @@ module OperationHelper
     AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/routes/route1", AdminUI::Utils::HTTP_DELETE, anything, anything, anything) do
       Net::HTTPNoContent.new(1.0, 204, 'OK')
     end
+
+    AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/service_plans/service_plan1", AdminUI::Utils::HTTP_PUT, anything, '{"public": true }', anything) do
+      Created.new(cc_public_service_plans)
+    end
+
+    AdminUI::Utils.stub(:http_request).with(anything, "#{ config.cloud_controller_uri }/v2/service_plans/service_plan1", AdminUI::Utils::HTTP_PUT, anything, '{"public": false }', anything) do
+      Created.new(cc_private_service_plans)
+    end
   end
 end

--- a/spec/support/web_helper.rb
+++ b/spec/support/web_helper.rb
@@ -63,6 +63,8 @@ shared_context :web_context do
       expect(properties[property_index].text).to eq("#{ expected_property[:label] }:")
       if expected_property[:tag].nil?
         value = values[property_index].text
+      elsif  expected_property[:tag] == 'img'
+        value = values[property_index].find_element(:tag_name => 'div').attribute('innerHTML')
       else
         value = values[property_index].find_element(:tag_name => expected_property[:tag]).text
       end
@@ -83,6 +85,13 @@ shared_context :web_context do
     expect(@driver.find_element(:xpath => "//table[@id='#{ target_tab_id }Table']/tbody/tr[contains(@class, 'DTTT_selected')]/td[1]").text).to eq(expected_name)
     expect(@driver.find_element(:id => "#{ target_tab_id }DetailsLabel").displayed?).to be_true
     expect(@driver.find_elements(:xpath => "//div[@id='#{ target_tab_id }PropertiesContainer']/table/tr[*]/td[2]")[0].text).to eq(expected_name)
+  end
+
+  def check_main_table_link(tab_id, column_index, target_tab_id, target_colmn_idex, expected_name)
+    @driver.find_element(:xpath => "//table[@id='#{ tab_id }Table']/tbody/tr[1]/td[#{column_index}]").find_element(:link, '1').click
+    expect(@driver.find_element(:class_name => 'menuItemSelected').attribute('id')).to eq(target_tab_id)
+    expect(@driver.find_element(:id => "#{ target_tab_id }Table_filter").find_element(:tag_name => 'input').attribute('value')).to eq(expected_name)
+    expect(@driver.find_elements(:xpath => "//table[@id='#{ target_tab_id }Table']/tbody/tr[*]/td[#{target_colmn_idex}]")[0].text).to eq(expected_name)
   end
 
   def check_stats_chart(id)


### PR DESCRIPTION
Added service plan tab with following features:
     1) The tab must consist of a main table and a details table
     2) There should be a span across the service columns and a span across the service plan columns.  See service instances table for an example
     3) There should be a count of instances for this service plan with a detail link/filter to service instances.  The link must appear only on the details table.
     4)  There must be an action (button) with label "Public" and another action with label "Private"
     5)  There must be a link added to the Service Instances tab which takes user back to the Service Plans tab.
     6)  There must selenium-based test cases for the new Service Plans tab
