### PR TITLE
Fixed the problem of column misalignment between headers and body in the...

### DIFF
--- a/lib/admin/public/js/app/tabs/applicationsTab.js
+++ b/lib/admin/public/js/app/tabs/applicationsTab.js
@@ -56,7 +56,8 @@ ApplicationsTab.prototype.getColumns = function()
 {
     return [
                {
-                   "sTitle": "",
+                   "sTitle": "&nbsp;",
+                    "sWidth": "6px",
                    "sClass": "cellCenterAlign",
                    "bSortable": false,
                    "mRender": function(value, type)

--- a/lib/admin/public/js/app/tabs/organizationsTab.js
+++ b/lib/admin/public/js/app/tabs/organizationsTab.js
@@ -40,7 +40,8 @@ OrganizationsTab.prototype.getColumns = function()
 {
     return [
                {
-                   "sTitle": "",
+                   "sTitle": "&nbsp;",
+                    "sWidth": "2px",
                    "sClass": "cellCenterAlign",
                    "bSortable": false,
                    "mRender": function(value, type)

--- a/lib/admin/public/js/app/tabs/routesTab.js
+++ b/lib/admin/public/js/app/tabs/routesTab.js
@@ -54,7 +54,8 @@ RoutesTab.prototype.getColumns = function()
 {
     return [
                {
-                   "sTitle": "",
+                   "sTitle": "&nbsp;",
+                   "sWidth": "2px",
                    "sClass": "cellCenterAlign",
                    "bSortable": false,
                    "mRender": function(value, type)

--- a/lib/admin/public/js/app/tabs/servicePlansTab.js
+++ b/lib/admin/public/js/app/tabs/servicePlansTab.js
@@ -42,7 +42,8 @@ ServicePlansTab.prototype.getColumns = function()
 {
     return [
                 {
-                    "sTitle" : "",
+                    "sTitle": "&nbsp;",
+                    "sWidth": "3px",
                     "sClass" : "cellCenterAlign",
                     "bSortable" : false,
                     "mRender" : function(value, type) 

--- a/spec/integration/web/admin_spec.rb
+++ b/spec/integration/web/admin_spec.rb
@@ -82,7 +82,7 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
                               },
                               { :columns         => @driver.find_elements(:xpath => "//div[@id='OrganizationsTableContainer']/div/div[5]/div[1]/div/table/thead/tr[2]/th"),
                                 :expected_length => 23,
-                                :labels          => ['', 'Name', 'Status', 'Created', 'Spaces', 'Developers', 'Quota', 'Total', 'Used', 'Unused', 'Instances', 'Services', 'Memory', 'Disk', '% CPU', 'Memory', 'Disk', 'Total', 'Started', 'Stopped', 'Pending', 'Staged', 'Failed'],
+                                :labels          => [' ', 'Name', 'Status', 'Created', 'Spaces', 'Developers', 'Quota', 'Total', 'Used', 'Unused', 'Instances', 'Services', 'Memory', 'Disk', '% CPU', 'Memory', 'Disk', 'Total', 'Started', 'Stopped', 'Pending', 'Staged', 'Failed'],
                                 :colspans        => nil
                               }
                              ])
@@ -317,7 +317,7 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
                               {
                                 :columns         => @driver.find_elements(:xpath => "//div[@id='ApplicationsTableContainer']/div/div[5]/div[1]/div/table/thead/tr[2]/th"),
                                 :expected_length => 17,
-                                :labels          => ['', 'Name', 'State', "Package\nState", "Instance\nState", 'Started', 'URI', 'Buildpack', 'Instance', 'Services', 'Memory', 'Disk', '% CPU', 'Memory', 'Disk', 'Target', 'DEA'],
+                                :labels          => [' ', 'Name', 'State', "Package\nState", "Instance\nState", 'Started', 'URI', 'Buildpack', 'Instance', 'Services', 'Memory', 'Disk', '% CPU', 'Memory', 'Disk', 'Target', 'DEA'],
                                 :colspans        => nil
                               }
                              ])
@@ -497,7 +497,7 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
         it 'has a table' do
           check_table_layout([{ :columns         => @driver.find_elements(:xpath => "//div[@id='RoutesTableContainer']/div/div[5]/div[1]/div/table/thead/tr[1]/th"),
                                 :expected_length => 6,
-                                :labels          => ['', 'Host', 'Domain', 'Created', 'Target', 'Application'],
+                                :labels          => [' ', 'Host', 'Domain', 'Created', 'Target', 'Application'],
                                 :colspans        => nil
                               }
                               ])
@@ -682,7 +682,7 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
                               {
                                 :columns         => @driver.find_elements(:xpath => "//div[@id='ServicePlansTable_wrapper']/div[5]/div[1]/div/table/thead/tr[2]/th"),
                                 :expected_length => 12,
-                                :labels          => ['', 'Name', 'Created', 'Public', 'Service Instances', 'Provider', 'Label', 'Version', 'Created', 'Active', 'Bindable', 'Description'],
+                                :labels          => [' ', 'Name', 'Created', 'Public', 'Service Instances', 'Provider', 'Label', 'Version', 'Created', 'Active', 'Bindable', 'Description'],
                                 :colspans        => nil
                               }
                              ])


### PR DESCRIPTION
Fixed the problem of column misalignment between headers and body in the main table of organizations tab when it was viewed in Apple (Mac) Safari browser.
