### PR TITLE
gave a permanent fix to the security issue of allowScriptAccess in ZeroC...

### DIFF
--- a/lib/admin/public/application.html
+++ b/lib/admin/public/application.html
@@ -18,6 +18,8 @@
         <script src="js/external/jquery/DataTables-1.9.4/media/js/jquery.dataTables.min.js"></script>
         <script src="js/external/jquery/TableTools-2.1.5/media/js/TableTools.min.js"></script>
 
+        <script src="js/external/fixes/ZeroClipboard.js"></script>
+
         <script src="js/app/constants.js"></script>      
         <script src="js/app/utilities.js"></script>     
         <script src="js/app/format.js"></script>

--- a/lib/admin/public/js/external/fixes/ZeroClipboard.js
+++ b/lib/admin/public/js/external/fixes/ZeroClipboard.js
@@ -1,0 +1,19 @@
+ZeroClipboard_TableTools.Client.prototype.getHTML = function(width, height) {
+	// return HTML for movie
+	var html = '';
+	var flashvars = 'id=' + this.id + 
+		'&width=' + width + 
+		'&height=' + height;
+		
+	if (navigator.userAgent.match(/MSIE/)) {
+		// IE gets an OBJECT tag
+		var protocol = location.href.match(/^https/i) ? 'https://' : 'http://';
+		html += '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" codebase="'+protocol+'download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=10,0,0,0" width="'+width+'" height="'+height+'" id="'+this.movieId+'" align="middle"><param name="allowScriptAccess" value="sameDomain" /><param name="allowFullScreen" value="false" /><param name="movie" value="'+ZeroClipboard_TableTools.moviePath+'" /><param name="loop" value="false" /><param name="menu" value="false" /><param name="quality" value="best" /><param name="bgcolor" value="#ffffff" /><param name="flashvars" value="'+flashvars+'"/><param name="wmode" value="transparent"/></object>';
+	}
+	else {
+		// all other browsers get an EMBED tag
+		html += '<embed id="'+this.movieId+'" src="'+ZeroClipboard_TableTools.moviePath+'" loop="false" menu="false" quality="best" bgcolor="#ffffff" width="'+width+'" height="'+height+'" name="'+this.movieId+'" align="middle" allowScriptAccess="sameDomain" allowFullScreen="false" type="application/x-shockwave-flash" pluginspage="http://www.macromedia.com/go/getflashplayer" flashvars="'+flashvars+'" wmode="transparent" />';
+	}
+	return html;
+}
+


### PR DESCRIPTION
ZeroClipboard.js in the jquery plugin called 'DataTools' currently has allowScriptAccess set to 'always'.  This is a security bug which allows script injection issue to pop-up, mainly from other web sites that the user may have visited. A fix to this issue to set 
the allowScriptAccess flag to 'never'.  This PR aims at giving a permanent solution which can survive in future updates of DataTools until the implementation of getHTML method is changed.  This fix also allows users who wish the upgrade DataTools on their own environment to take advantage of the fixes without making code level changes.
