### PR TITLE
enable ssl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'net-sftp', '2.1.2'
 gem 'parse-cron', '0.1.4'
 gem 'sequel', '4.10.0'
 gem 'sqlite3', '1.3.9'
+gem 'rack-ssl', '1.4.1'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.1)
       rack
+    rack-ssl (1.4.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -58,6 +59,7 @@ DEPENDENCIES
   nats (= 0.4.26)
   net-sftp (= 2.1.2)
   parse-cron (= 0.1.4)
+  rack-ssl (= 1.4.1)
   rspec
   selenium-webdriver (= 2.39.0)
   sequel (= 4.10.0)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This has been tested on Ubuntu 10.04.4 64 bit, Ubuntu 12.04.3 64 bit and Ubuntu 
 ### Ubuntu Prerequisite Libraries
 
 ```
-sudo apt-get install -f -y --no-install-recommends git-core build-essential libssl-dev libsqlite3-dev
+sudo apt-get install -f -y --no-install-recommends git-core build-essential libssl-dev libsqlite3-dev openssl
 ```
 
 ### Ruby
@@ -236,6 +236,22 @@ Example: <code>[ ]</code>
 Example: <code>[bar@10.10.10.10, baz@10.10.10.10]</code>
 </dd>
 <dt>
+<code><b>secured_client_connection</b></code>
+</dt>
+<dd>
+A true/false indicator about whether the Admin-UI server process will operate in secure or unprotected 
+mode.  In the secure mode, Admin-UI uses SSL security mechanism to protect communication with its users.  
+As such, it requires its users to connect via https; in unprotected mode, Admin-UI expects http requests.
+<br>
+When set to 'true', a SSL certificate is required and the 'ssl' property must be present in the 
+configuration file.  Please see configuration property 'ssl' for details about how to configure Admin-UI 
+to work with SSL certificate.<br>
+By default, Admin-UI runs in the unprotected mode.
+<br>
+Example: <code>true</code>
+</dd>
+</dt>
+<dt>
 <code><b>sender_email</b></code>
 </dt>
 <dd>
@@ -257,6 +273,74 @@ Example: <code>10.10.10.10</code>
 The email account.
 <br>
 Example: <code>system@10.10.10.10</code>
+</dd>
+</dl>
+</dd>
+<dt>
+<code><b>ssl</b></code>
+</dt>
+<dd>
+A set of configuration properties for Admin-UI to work with SSL certificate.  It 
+is required when the 'secured_client_connection' is set to true.<br>
+Certificate can be self-signed or signed by Certificate Authority (CA).  Admin-UI 
+supports these certificates. However, intermediate certificate from CA is not yet 
+supported.<br>
+<b>Generate Self-signed certificate</b><br>
+You can generate a self-signed certificate on a server, all without involving 
+third-party CA.  The following steps illustrate a way in how you can generate a 
+self-signed certificate:
+* generate private key
+<pre>
+openssl genrsa -des3 -out /tmp/admin_ui_server.key -3 -passout pass:private_key_pass_phrase 2048
+</pre>
+This command creates a private key at 2048 bit length which is then encrypted with 
+passphrase 'pass:private_key_pass_phrase' by way of DES3.
+* Generate certificate request
+<pre>
+openssl req -new -key /tmp/admin_ui_server.key -out /tmp/admin_ui_server.csr -passin pass:private_key_pass_phrase
+</pre>
+This command yields a certificate request file by supplying the private key and 
+passphrase involved in the previous step.
+* Generate certificate
+<pre>
+openssl x509 -req -days 365 -passin pass:private_key_pass -in /tmp/admin_ui_server.csr -signkey /tmp/admin_ui_server.key -out /tmp/admin_ui_server.crt
+</pre>
+This command generates a certificate that is good for the next 365 days.  At this 
+point, you no longer need to keep the certificate request (dot csr file).
+<br>
+<dl>
+<dt>
+<code>certificate_file_path</code>
+</dt>
+<dd>
+File path string leading to the certificate file.
+<br>
+Example: <code>certificate/server.cert</code>
+</dd>
+<dt>
+<dt>
+<code>max_session_idle_length</code>
+</dt>
+<dd>
+Time duration in seconds in which a https session is allowed to stay idle.
+<br>
+Example: <code>1800</code> for 30 minutes.
+</dd>
+<dt>
+<code>private_key_file_path</code>
+</dt>
+<dd>
+File path string leading to the private key file.
+<br>
+Example: <code>system@10.10.10.10</code>
+</dd>
+<dt>
+<code>private_key_pass_phrase</code>
+</dt>
+<dd>
+Password string that is used to encrypt the private key.
+<br>
+Example: <code>my_secret</code>
 </dd>
 </dl>
 </dd>

--- a/lib/admin/config.rb
+++ b/lib/admin/config.rb
@@ -17,6 +17,7 @@ module AdminUI
       :nats_discovery_interval             =>                 30,
       :nats_discovery_timeout              =>                 10,
       :receiver_emails                     =>                 [],
+      :secured_client_connection           =>              false,
       :stats_refresh_schedules             =>      ['0 5 * * *'],
       :stats_retries                       =>                  5,
       :stats_retry_interval                =>                300,
@@ -51,6 +52,14 @@ module AdminUI
           {
             :server  => /[^\r\n\t]+/,
             :account => /[^\r\n\t]+/
+          },
+          :secured_client_connection                     => bool,
+          optional(:ssl)                                 =>
+          {
+            :certificate_file_path     => String,
+            :private_key_file_path     => String,
+            :private_key_pass_phrase   => String,
+            :max_session_idle_length   => Integer
           },
           optional(:stats_file)                          => /[^\r\n\t]+/,
           optional(:stats_refresh_time)                  => Integer,
@@ -175,6 +184,10 @@ module AdminUI
       @config[:receiver_emails]
     end
 
+    def secured_client_connection
+      @config[:secured_client_connection]
+    end
+
     def sender_email_account
       return nil if @config[:sender_email].nil?
       @config[:sender_email][:account]
@@ -183,6 +196,26 @@ module AdminUI
     def sender_email_server
       return nil if @config[:sender_email].nil?
       @config[:sender_email][:server]
+    end
+
+    def ssl_certificate_file_path
+      return nil if @config[:ssl].nil?
+      @config[:ssl][:certificate_file_path]
+    end
+
+    def ssl_max_session_idle_length
+      return nil if @config[:ssl].nil?
+      @config[:ssl][:max_session_idle_length]
+    end
+
+    def ssl_private_key_file_path
+      return nil if @config[:ssl].nil?
+      @config[:ssl][:private_key_file_path]
+    end
+
+    def ssl_private_key_pass_phrase
+      return nil if @config[:ssl].nil?
+      @config[:ssl][:private_key_pass_phrase]
     end
 
     def stats_file

--- a/lib/admin/secure_web.rb
+++ b/lib/admin/secure_web.rb
@@ -1,0 +1,21 @@
+require 'rack/ssl'
+require 'sinatra'
+require_relative 'web'
+
+module AdminUI
+  class SecureWeb < AdminUI::Web
+    def initialize(config, logger, cc, login, log_files, operation, stats, tasks, varz, view_models)
+      logger.debug 'use AdminUI::SecureWeb'
+      super(config, logger, cc, login, log_files, operation, stats, tasks, varz, view_models)
+    end
+
+    configure do
+      enable :sessions
+      set :static_cache_control, :no_cache
+      set :environment, :production
+      set :show_exceptions, false
+      use Rack::SSL, :exclude => ->(env) { env['RACK_ENV'] != 'production' }
+      use Rack::Session::Cookie, :secure => true, :expire_after => 60, :secret => 'mysecre'
+    end
+  end
+end

--- a/lib/admin/web.rb
+++ b/lib/admin/web.rb
@@ -28,6 +28,7 @@ module AdminUI
     set(:auth) do |*roles|
       condition do
         unless session[:username] && (!roles.include?(:admin) || session[:admin])
+          env['rack.session.options'][:expire_after] = @config.ssl_max_session_idle_length.to_i if @config.secured_client_connection
           @logger.debug('Authorization failure, redirecting to login...')
           redirect_to_login
         end

--- a/spec/ssl/openssl.cnf
+++ b/spec/ssl/openssl.cnf
@@ -1,0 +1,15 @@
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+C = US
+ST = CA
+L = San Jose
+O = ibm
+CN = localhost
+
+[v3_req]
+subjectKeyIdentifier = hash
+basicConstraints = CA:TRUE

--- a/spec/unit/admin_spec.rb
+++ b/spec/unit/admin_spec.rb
@@ -1,4 +1,6 @@
 require 'fileutils'
+require 'net/https'
+require 'openssl'
 require 'uri'
 require_relative '../spec_helper'
 
@@ -15,21 +17,35 @@ describe AdminUI::Admin do
   let(:log_file) { '/tmp/admin_ui.log' }
   let(:stats_file) { '/tmp/admin_ui_stats.json' }
   let(:tasks_refresh_interval) { 6000 }
+  let(:secured_client_connection) { false }
+  let(:certificate_file_path)   { '/tmp/admin_ui_server.crt' }
+  let(:certificate_request_file_path) { '/tmp/admin_ui_server.csr' }
+  let(:private_key_file_path)   { '/tmp/admin_ui_server.key' }
+  let(:private_key_pass_phrase) { 'private_key_pass_phrase'  }
+  let(:openssl_config) { 'spec/ssl/openssl.cnf' }
 
   let(:config) do
-    { :cloud_controller_uri   => cloud_controller_uri,
-      :data_file              => data_file,
-      :db_uri                 => "sqlite://#{ db_file }",
-      :log_file               => log_file,
-      :mbus                   => 'nats://nats:c1oudc0w@localhost:14222',
-      :port                   => port,
-      :stats_file             => stats_file,
-      :tasks_refresh_interval => tasks_refresh_interval,
+    { :cloud_controller_uri                => cloud_controller_uri,
+      :data_file                           => data_file,
+      :db_uri                              => "sqlite://#{ db_file }",
+      :log_file                            => log_file,
+      :mbus                                => 'nats://nats:c1oudc0w@localhost:14222',
+      :port                                => port,
+      :secured_client_connection           => secured_client_connection,
+      :ssl                                 => { :certificate_file_path   => certificate_file_path,
+                                                :private_key_file_path   => private_key_file_path,
+                                                :private_key_pass_phrase => private_key_pass_phrase,
+                                                :max_session_idle_length => 1000
+                                               },
+      :stats_file                          => stats_file,
+      :tasks_refresh_interval              => tasks_refresh_interval,
       :uaa_client             => { :id => 'id', :secret => 'secret' }
     }
   end
 
   before do
+    generate_certificate if secured_client_connection
+
     File.delete(db_file) if File.exist?(db_file)
 
     ::WEBrick::Log.any_instance.stub(:log)
@@ -42,6 +58,12 @@ describe AdminUI::Admin do
   end
 
   after do
+    if secured_client_connection
+      FileUtils.rm_rf(certificate_file_path)
+      FileUtils.rm_rf(certificate_request_file_path)
+      FileUtils.rm_rf(private_key_file_path)
+    end
+
     Rack::Handler::WEBrick.shutdown
 
     Thread.list.each do |thread|
@@ -54,8 +76,19 @@ describe AdminUI::Admin do
     Process.wait(Process.spawn({}, "rm -fr #{ data_file } #{ db_file } #{ log_file } #{ stats_file }"))
   end
 
+  def generate_certificate
+    system "openssl genrsa -des3 -out #{ private_key_file_path } -3 -passout pass:#{private_key_pass_phrase} 1024 > /dev/null 2>&1"
+    system "openssl req -new -key #{ private_key_file_path } -out #{ certificate_request_file_path } -passin pass:#{ private_key_pass_phrase } -config #{ openssl_config } > /dev/null 2>&1"
+    system "openssl x509 -req -days 365 -in #{ certificate_request_file_path } -signkey #{ private_key_file_path } -out #{ certificate_file_path } -passin pass:#{ private_key_pass_phrase } > /dev/null 2>&1"
+  end
+
   def create_http
-    Net::HTTP.new(host, port)
+    http = Net::HTTP.new(host, port)
+    if secured_client_connection
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+    http
   end
 
   def login_and_return_cookie(http)
@@ -70,7 +103,11 @@ describe AdminUI::Admin do
       request['Cookie'] = cookie
 
       response = http.request(request)
-      cookie   = response['Set-Cookie'] unless response['Set-Cookie'].nil?
+      if secured_client_connection
+        cookie = { 'cookie' => response.to_hash['set-cookie'].map { |ea|ea[/^.*?;/] }.join }
+      else
+        cookie = response['Set-Cookie'] unless response['Set-Cookie'].nil?
+      end
 
       break unless response['location']
       uri = URI.parse(response['location'])
@@ -96,10 +133,7 @@ describe AdminUI::Admin do
     cookie
   end
 
-  context 'Destroys the session after logout' do
-    before do
-      login_stub_admin
-    end
+  shared_examples 'common_destroys the session after logout' do
     it 'destroys the session after logout' do
       original_cookie = login_and_return_cookie(create_http)
       new_cookie      = logout(create_http)
@@ -108,12 +142,24 @@ describe AdminUI::Admin do
     end
   end
 
-  context 'Login required, performed and failed' do
+  context 'Destroys the plain http session after logout' do
     before do
-      login_stub_fail
+      login_stub_admin
     end
-    let(:http) { create_http }
+    it_behaves_like('common_destroys the session after logout')
+  end
 
+  context 'Destroys the https session after logout' do
+    before do
+      login_stub_admin
+    end
+    let(:secured_client_connection) { true }
+
+    it_behaves_like('common_destroys the session after logout')
+  end
+
+  shared_examples 'common Login required, performed and failed' do
+    let(:http) { create_http }
     it 'login fails as expected' do
       request = Net::HTTP::Get.new('/')
 
@@ -123,28 +169,32 @@ describe AdminUI::Admin do
       location = response['location']
       expect(location).not_to be_nil
     end
+
+  end
+
+  context 'Login required, performed and failed via http' do
+    before do
+      login_stub_fail
+    end
+
+    it_behaves_like 'common Login required, performed and failed'
+  end
+
+  context 'Login required, performed and failed https' do
+    before do
+      login_stub_fail
+    end
+    let(:secured_client_connection) { true }
+
+    it_behaves_like 'common Login required, performed and failed'
   end
 
   context 'Login required, performed and succeeded' do
     before do
       login_stub_admin
     end
-
     let(:http)   { create_http }
     let(:cookie) { login_and_return_cookie(http) }
-
-    def get_json(path)
-      request = Net::HTTP::Get.new(path)
-      request['Cookie'] = cookie
-
-      response = http.request(request)
-      expect(response.is_a?(Net::HTTPOK)).to be_true
-
-      body = response.body
-      expect(body).to_not be_nil
-
-      JSON.parse(body)
-    end
 
     def put(path, body)
       request = Net::HTTP::Put.new(path)
@@ -171,10 +221,141 @@ describe AdminUI::Admin do
       http.request(request)
     end
 
-    def verify_disconnected_items(path)
-      json = get_json(path)
+    shared_examples 'common create organization' do
+      it 'returns failure code due to disconnection' do
+        response = post('/organizations', '{"name":"new_org"}')
+        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
+      end
+    end
 
-      expect(json).to include('connected' => false, 'items' => [])
+    context 'create organization via http' do
+      it_behaves_like('common create organization')
+    end
+
+    context 'create organization via https' do
+      let(:secured_client_connection) { true }
+
+      it_behaves_like('common create organization')
+    end
+
+    shared_examples 'common delete application' do
+      it 'returns failure code due to disconnection' do
+        response = delete('/applications/application1')
+        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
+      end
+    end
+
+    context 'delete application via http' do
+      it_behaves_like('common delete application')
+    end
+
+    context 'delete application via https' do
+      let(:secured_client_connection) { true }
+
+      it_behaves_like('common delete application')
+    end
+
+    shared_examples 'common delete organization' do
+      it 'returns failure code due to disconnection' do
+        response = delete('/organizations/organization1')
+        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
+      end
+    end
+
+    context 'delete organization via http' do
+      it_behaves_like('common delete organization')
+    end
+
+    context 'delete organization via https' do
+      let(:secured_client_connection) { true }
+
+      it_behaves_like('common delete organization')
+    end
+
+    shared_examples 'common delete route' do
+      it 'returns failure code due to disconnection' do
+        response = delete('/routes/route1')
+        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
+      end
+    end
+
+    context 'delete route via http' do
+      it_behaves_like('common delete route')
+    end
+
+    context 'delete route via https' do
+      let(:secured_client_connection) { true }
+
+      it_behaves_like('common delete route')
+    end
+
+    shared_examples 'common manage application' do
+      it 'returns failure code due to disconnection' do
+        response = put('/applications/application1', '{"state":"STARTED"}')
+        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
+      end
+    end
+
+    context 'manage application via http' do
+      it_behaves_like('common manage application')
+    end
+
+    context 'manage application via https' do
+      let(:secured_client_connection) { true }
+
+      it_behaves_like('common manage application')
+    end
+
+    shared_examples 'common manage organization' do
+      it 'returns failure code due to disconnection' do
+        response = put('/organizations/organization1', '{"quota_definition_guid":"quota1"}')
+        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
+      end
+    end
+
+    context 'manage organization via http' do
+      it_behaves_like('common manage organization')
+    end
+
+    context 'manage organization via https' do
+      let(:secured_client_connection) { true }
+
+      it_behaves_like('common manage organization')
+    end
+
+    shared_examples 'common manage service plan' do
+      it 'returns failure code due to disconnection' do
+        response = put('/service_plans/service_plan1', '{"public": true }')
+        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
+      end
+    end
+
+    context 'manage service plan via http' do
+      it_behaves_like('common manage organization')
+    end
+
+    context 'manage service plan via https' do
+      let(:secured_client_connection) { true }
+
+      it_behaves_like('common manage service plan')
+    end
+  end
+
+  context 'Login required; REST services performed and succeeded' do
+    let(:http)   { create_http }
+    let(:cookie) { login_and_return_cookie(http) }
+
+    def get_json(path)
+      request = Net::HTTP::Get.new(path)
+      request['Cookie'] = cookie
+
+      response = http.request(request)
+      expect(response.is_a?(Net::HTTPOK)).to be_true
+
+      body = response.body
+      expect(body).to_not be_nil
+
+      JSON.parse(body)
     end
 
     def verify_view_model_items(path, connected)
@@ -194,220 +375,192 @@ describe AdminUI::Admin do
       verify_view_model_items(path, false)
     end
 
+    def verify_disconnected_items(path)
+      json = get_json(path)
+      expect(json).to include('connected' => false, 'items' => [])
+    end
+
     def verify_empty_items(path)
       json = get_json(path)
 
       expect(json).to include('items' => [])
     end
 
-    context 'create organization' do
-      it 'returns failure code due to disconnection' do
-        response = post('/organizations', '{"name":"new_org"}')
-        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
+    shared_examples 'common /all tabs succeed' do
+      before do
+        login_stub_admin
+      end
+
+      it '/applications succeeds' do
+        verify_disconnected_items('/applications')
+      end
+
+      it '/applications_view_model succeeds' do
+        verify_disconnected_view_model_items('/applications_view_model')
+      end
+
+      it '/cloud_controllers succeeds' do
+        verify_disconnected_items('/cloud_controllers')
+      end
+
+      it '/cloud_controllers_view_model succeeds' do
+        verify_disconnected_view_model_items('/cloud_controllers_view_model')
+      end
+
+      it '/components succeeds' do
+        verify_disconnected_items('/components')
+      end
+
+      it '/components_view_model succeeds' do
+        verify_disconnected_view_model_items('/components_view_model')
+      end
+
+      it '/deas succeeds' do
+        verify_disconnected_items('/deas')
+      end
+
+      it '/deas_view_model succeeds' do
+        verify_disconnected_view_model_items('/deas_view_model')
+      end
+
+      it '/developers_view_model succeeds' do
+        verify_disconnected_view_model_items('/developers_view_model')
+      end
+
+      it '/gateways succeeds' do
+        verify_disconnected_items('/gateways')
+      end
+
+      it '/gateways_view_model succeeds' do
+        verify_disconnected_view_model_items('/gateways_view_model')
+      end
+
+      it '/health_managers succeeds' do
+        verify_disconnected_items('/health_managers')
+      end
+
+      it '/health_managers_view_model succeeds' do
+        verify_disconnected_view_model_items('/health_managers_view_model')
+      end
+
+      it '/logs succeeds' do
+        verify_empty_items('/logs')
+      end
+
+      it '/logs_view_model succeeds' do
+        verify_connected_view_model_empty_items('/logs_view_model')
+      end
+
+      it '/organizations succeeds' do
+        verify_disconnected_items('/organizations')
+      end
+
+      it '/organizations_view_model succeeds' do
+        verify_disconnected_view_model_items('/organizations_view_model')
+      end
+
+      it '/quota_definitions succeeds' do
+        verify_disconnected_items('/quota_definitions')
+      end
+
+      it '/quotas_view_model succeeds' do
+        verify_disconnected_view_model_items('/quotas_view_model')
+      end
+
+      it '/routers succeeds' do
+        verify_disconnected_items('/routers')
+      end
+
+      it '/routers_view_model succeeds' do
+        verify_disconnected_view_model_items('/routers_view_model')
+      end
+
+      it '/routes succeeds' do
+        verify_disconnected_items('/routes')
+      end
+
+      it '/routes_view_model succeeds' do
+        verify_disconnected_view_model_items('/routes_view_model')
+      end
+
+      it '/settings succeeds' do
+        json = get_json('/settings')
+
+        expect(json).to eq('admin'                  => true,
+                           'cloud_controller_uri'   => cloud_controller_uri,
+                           'tasks_refresh_interval' => tasks_refresh_interval)
+
+      end
+
+      it '/services succeeds' do
+        verify_disconnected_items('/services')
+      end
+
+      it '/service_bindings succeeds' do
+        verify_disconnected_items('/service_bindings')
+      end
+
+      it '/service_brokers succeeds' do
+        verify_disconnected_items('/service_brokers')
+      end
+
+      it '/service_instances succeeds' do
+        verify_disconnected_items('/service_instances')
+      end
+
+      it '/service_instances_view_model succeeds' do
+        verify_disconnected_view_model_items('/service_instances_view_model')
+      end
+
+      it '/service_plans succeeds' do
+        verify_disconnected_items('/service_plans')
+      end
+
+      it '/service_plans_view_model succeeds' do
+        verify_disconnected_view_model_items('/service_plans_view_model')
+      end
+
+      it '/spaces succeeds' do
+        verify_disconnected_items('/spaces')
+      end
+
+      it '/spaces_view_model succeeds' do
+        verify_disconnected_view_model_items('/spaces_view_model')
+      end
+
+      it '/spaces_auditors succeeds' do
+        verify_disconnected_items('/spaces_auditors')
+      end
+
+      it '/spaces_developers succeeds' do
+        verify_disconnected_items('/spaces_developers')
+      end
+
+      it '/spaces_managers succeeds' do
+        verify_disconnected_items('/spaces_managers')
+      end
+
+      it '/tasks succeeds' do
+        verify_empty_items('/tasks')
+      end
+
+      it '/tasks_view_model succeeds' do
+        verify_connected_view_model_empty_items('/tasks_view_model')
+      end
+
+      it '/users succeeds' do
+        verify_disconnected_items('/users')
       end
     end
 
-    context 'delete application' do
-      it 'returns failure code due to disconnection' do
-        response = delete('/applications/application1')
-        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
-      end
+    context '/applications via http' do
+      it_behaves_like('common /all tabs succeed')
     end
 
-    context 'delete organization' do
-      it 'returns failure code due to disconnection' do
-        response = delete('/organizations/organization1')
-        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
-      end
-    end
+    context '/applications via https' do
+      let(:secured_client_connection) { true }
 
-    context 'delete route' do
-      it 'returns failure code due to disconnection' do
-        response = delete('/routes/route1')
-        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
-      end
-    end
-
-    context 'manage application' do
-      it 'returns failure code due to disconnection' do
-        response = put('/applications/application1', '{"state":"STARTED"}')
-        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
-      end
-    end
-
-    context 'manage organization' do
-      it 'returns failure code due to disconnection' do
-        response = put('/organizations/organization1', '{"quota_definition_guid":"quota1"}')
-        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
-      end
-    end
-
-    context 'manage service plan' do
-      it 'returns failure code due to disconnection' do
-        response = put('/service_plans/service_plan1', '{"public": true }')
-        expect(response.is_a?(Net::HTTPInternalServerError)).to be_true
-      end
-    end
-
-    it '/applications succeeds' do
-      verify_disconnected_items('/applications')
-    end
-
-    it '/applications_view_model succeeds' do
-      verify_disconnected_view_model_items('/applications_view_model')
-    end
-
-    it '/cloud_controllers succeeds' do
-      verify_disconnected_items('/cloud_controllers')
-    end
-
-    it '/cloud_controllers_view_model succeeds' do
-      verify_disconnected_view_model_items('/cloud_controllers_view_model')
-    end
-
-    it '/components succeeds' do
-      verify_disconnected_items('/components')
-    end
-
-    it '/components_view_model succeeds' do
-      verify_disconnected_view_model_items('/components_view_model')
-    end
-
-    it '/deas succeeds' do
-      verify_disconnected_items('/deas')
-    end
-
-    it '/deas_view_model succeeds' do
-      verify_disconnected_view_model_items('/deas_view_model')
-    end
-
-    it '/developers_view_model succeeds' do
-      verify_disconnected_view_model_items('/developers_view_model')
-    end
-
-    it '/gateways succeeds' do
-      verify_disconnected_items('/gateways')
-    end
-
-    it '/gateways_view_model succeeds' do
-      verify_disconnected_view_model_items('/gateways_view_model')
-    end
-
-    it '/health_managers succeeds' do
-      verify_disconnected_items('/health_managers')
-    end
-
-    it '/health_managers_view_model succeeds' do
-      verify_disconnected_view_model_items('/health_managers_view_model')
-    end
-
-    it '/logs succeeds' do
-      verify_empty_items('/logs')
-    end
-
-    it '/logs_view_model succeeds' do
-      verify_connected_view_model_empty_items('/logs_view_model')
-    end
-
-    it '/organizations succeeds' do
-      verify_disconnected_items('/organizations')
-    end
-
-    it '/organizations_view_model succeeds' do
-      verify_disconnected_view_model_items('/organizations_view_model')
-    end
-
-    it '/quota_definitions succeeds' do
-      verify_disconnected_items('/quota_definitions')
-    end
-
-    it '/quotas_view_model succeeds' do
-      verify_disconnected_view_model_items('/quotas_view_model')
-    end
-
-    it '/routers succeeds' do
-      verify_disconnected_items('/routers')
-    end
-
-    it '/routers_view_model succeeds' do
-      verify_disconnected_view_model_items('/routers_view_model')
-    end
-
-    it '/routes succeeds' do
-      verify_disconnected_items('/routes')
-    end
-
-    it '/routes_view_model succeeds' do
-      verify_disconnected_view_model_items('/routes_view_model')
-    end
-
-    it '/settings succeeds' do
-      json = get_json('/settings')
-
-      expect(json).to eq('admin'                  => true,
-                         'cloud_controller_uri'   => cloud_controller_uri,
-                         'tasks_refresh_interval' => tasks_refresh_interval)
-
-    end
-
-    it '/services succeeds' do
-      verify_disconnected_items('/services')
-    end
-
-    it '/service_bindings succeeds' do
-      verify_disconnected_items('/service_bindings')
-    end
-
-    it '/service_brokers succeeds' do
-      verify_disconnected_items('/service_brokers')
-    end
-
-    it '/service_instances succeeds' do
-      verify_disconnected_items('/service_instances')
-    end
-
-    it '/service_instances_view_model succeeds' do
-      verify_disconnected_view_model_items('/service_instances_view_model')
-    end
-
-    it '/service_plans succeeds' do
-      verify_disconnected_items('/service_plans')
-    end
-
-    it '/service_plans_view_model succeeds' do
-      verify_disconnected_view_model_items('/service_plans_view_model')
-    end
-
-    it '/spaces succeeds' do
-      verify_disconnected_items('/spaces')
-    end
-
-    it '/spaces_view_model succeeds' do
-      verify_disconnected_view_model_items('/spaces_view_model')
-    end
-
-    it '/spaces_auditors succeeds' do
-      verify_disconnected_items('/spaces_auditors')
-    end
-
-    it '/spaces_developers succeeds' do
-      verify_disconnected_items('/spaces_developers')
-    end
-
-    it '/spaces_managers succeeds' do
-      verify_disconnected_items('/spaces_managers')
-    end
-
-    it '/tasks succeeds' do
-      verify_empty_items('/tasks')
-    end
-
-    it '/tasks_view_model succeeds' do
-      verify_connected_view_model_empty_items('/tasks_view_model')
-    end
-
-    it '/users succeeds' do
-      verify_disconnected_items('/users')
+      it_behaves_like('common /all tabs succeed')
     end
   end
 
@@ -448,205 +601,220 @@ describe AdminUI::Admin do
       expect(location).not_to be_nil
     end
 
-    it '/applications redirects as expected' do
-      get_redirects_as_expected('/applications')
+    shared_examples 'common /all tabs redirect' do
+      before do
+        login_stub_fail
+      end
+      let(:http) { create_http }
+
+      it '/applications redirects as expected' do
+        get_redirects_as_expected('/applications')
+      end
+
+      it '/applications_view_model redirects as expected' do
+        get_redirects_as_expected('/applications_view_model')
+      end
+
+      it '/cloud_controllers redirects as expected' do
+        get_redirects_as_expected('/cloud_controllers')
+      end
+
+      it '/cloud_controllers_view_model redirects as expected' do
+        get_redirects_as_expected('/cloud_controllers_view_model')
+      end
+
+      it '/components redirects as expected' do
+        get_redirects_as_expected('/components')
+      end
+
+      it '/components_view_model redirects as expected' do
+        get_redirects_as_expected('/components_view_model')
+      end
+
+      it '/deas redirects as expected' do
+        get_redirects_as_expected('/deas')
+      end
+
+      it '/deas_view_model redirects as expected' do
+        get_redirects_as_expected('/deas_view_model')
+      end
+
+      it '/developers_view_model redirects as expected' do
+        get_redirects_as_expected('/developers_view_model')
+      end
+
+      it '/download redirects as expected' do
+        get_redirects_as_expected('/download')
+      end
+
+      it '/gateways redirects as expected' do
+        get_redirects_as_expected('/gateways')
+      end
+
+      it '/gateways_view_model redirects as expected' do
+        get_redirects_as_expected('/gateways_view_model')
+      end
+
+      it '/health_managers redirects as expected' do
+        get_redirects_as_expected('/health_managers')
+      end
+
+      it '/health_managers_view_model redirects as expected' do
+        get_redirects_as_expected('/health_managers_view_model')
+      end
+
+      it '/log redirects as expected' do
+        get_redirects_as_expected('/log')
+      end
+
+      it '/logs redirects as expected' do
+        get_redirects_as_expected('/logs')
+      end
+
+      it '/logs_view_model redirects as expected' do
+        get_redirects_as_expected('/logs_view_model')
+      end
+
+      it '/organizations redirects as expected' do
+        get_redirects_as_expected('/organizations')
+      end
+
+      it '/organizations_view_model redirects as expected' do
+        get_redirects_as_expected('/organizations_view_model')
+      end
+
+      it '/quota_definitions redirects as expected' do
+        get_redirects_as_expected('/quota_definitions')
+      end
+
+      it '/quotas_view_model redirects as expected' do
+        get_redirects_as_expected('/quotas_view_model')
+      end
+
+      it '/routers redirects as expected' do
+        get_redirects_as_expected('/routers')
+      end
+
+      it '/routers_view_model redirects as expected' do
+        get_redirects_as_expected('/routers_view_model')
+      end
+
+      it '/routes redirects as expected' do
+        get_redirects_as_expected('/routes')
+      end
+
+      it '/routes_view_model redirects as expected' do
+        get_redirects_as_expected('/routes_view_model')
+      end
+
+      it '/settings redirects as expected' do
+        get_redirects_as_expected('/settings')
+      end
+
+      it '/services redirects as expected' do
+        get_redirects_as_expected('/services')
+      end
+
+      it '/service_bindings redirects as expected' do
+        get_redirects_as_expected('/service_bindings')
+      end
+
+      it '/service_brokers redirects as expected' do
+        get_redirects_as_expected('/service_brokers')
+      end
+
+      it '/service_instances redirects as expected' do
+        get_redirects_as_expected('/service_instances')
+      end
+
+      it '/service_instances_view_model redirects as expected' do
+        get_redirects_as_expected('/service_instances_view_model')
+      end
+
+      it '/service_plans redirects as expected' do
+        get_redirects_as_expected('/service_plans')
+      end
+
+      it '/service_plans_view_model redirects as expected' do
+        get_redirects_as_expected('/service_plans_view_model')
+      end
+
+      it '/spaces redirects as expected' do
+        get_redirects_as_expected('/spaces')
+      end
+
+      it '/spaces_view_model redirects as expected' do
+        get_redirects_as_expected('/spaces_view_model')
+      end
+
+      it '/spaces_auditors redirects as expected' do
+        get_redirects_as_expected('/spaces_auditors')
+      end
+
+      it '/spaces_developers redirects as expected' do
+        get_redirects_as_expected('/spaces_developers')
+      end
+
+      it '/spaces_managersd redirects as expected' do
+        get_redirects_as_expected('/spaces_managers')
+      end
+
+      it '/tasks redirects as expected' do
+        get_redirects_as_expected('/tasks')
+      end
+
+      it '/tasks_view_model redirects as expected' do
+        get_redirects_as_expected('/tasks_view_model')
+      end
+
+      it '/task_status redirects as expected' do
+        get_redirects_as_expected('/task_status')
+      end
+
+      it '/users redirects as expected' do
+        get_redirects_as_expected('/users')
+      end
+
+      it 'deletes /applications/:app_guid redirects as expected' do
+        delete_redirects_as_expected('/applications/application1')
+      end
+
+      it 'deletes /organizations/:org_guid redirects as expected' do
+        delete_redirects_as_expected('/organizations/organization1')
+      end
+
+      it 'deletes /routes/:route_guid redirects as expected' do
+        delete_redirects_as_expected('/routes/route1')
+      end
+
+      it 'posts /organizations redirects as expected' do
+        post_redirects_as_expected('/organizations', '{"name":"new_org"}')
+      end
+
+      it 'puts /applications/:app_guid redirects as expected' do
+        put_redirects_as_expected('/applications/application1', '{"state":"STARTED"}')
+      end
+
+      it 'puts /organizations/:org_guid redirects as expected' do
+        put_redirects_as_expected('/organizations/organization1', '{"quota_definition_guid":"quota1"}')
+      end
+
+      it 'puts /service_plans/:service_plan_guid redirects as expected' do
+        put_redirects_as_expected('/service_plans/application1', '{"public":true}')
+      end
     end
 
-    it '/applications_view_model redirects as expected' do
-      get_redirects_as_expected('/applications_view_model')
+    context '/all tabs via http' do
+      it_behaves_like('common /all tabs redirect')
     end
 
-    it '/cloud_controllers redirects as expected' do
-      get_redirects_as_expected('/cloud_controllers')
-    end
-
-    it '/cloud_controllers_view_model redirects as expected' do
-      get_redirects_as_expected('/cloud_controllers_view_model')
-    end
-
-    it '/components redirects as expected' do
-      get_redirects_as_expected('/components')
-    end
-
-    it '/components_view_model redirects as expected' do
-      get_redirects_as_expected('/components_view_model')
-    end
-
-    it '/deas redirects as expected' do
-      get_redirects_as_expected('/deas')
-    end
-
-    it '/deas_view_model redirects as expected' do
-      get_redirects_as_expected('/deas_view_model')
-    end
-
-    it '/developers_view_model redirects as expected' do
-      get_redirects_as_expected('/developers_view_model')
-    end
-
-    it '/download redirects as expected' do
-      get_redirects_as_expected('/download')
-    end
-
-    it '/gateways redirects as expected' do
-      get_redirects_as_expected('/gateways')
-    end
-
-    it '/gateways_view_model redirects as expected' do
-      get_redirects_as_expected('/gateways_view_model')
-    end
-
-    it '/health_managers redirects as expected' do
-      get_redirects_as_expected('/health_managers')
-    end
-
-    it '/health_managers_view_model redirects as expected' do
-      get_redirects_as_expected('/health_managers_view_model')
-    end
-
-    it '/log redirects as expected' do
-      get_redirects_as_expected('/log')
-    end
-
-    it '/logs redirects as expected' do
-      get_redirects_as_expected('/logs')
-    end
-
-    it '/logs_view_model redirects as expected' do
-      get_redirects_as_expected('/logs_view_model')
-    end
-
-    it '/organizations redirects as expected' do
-      get_redirects_as_expected('/organizations')
-    end
-
-    it '/organizations_view_model redirects as expected' do
-      get_redirects_as_expected('/organizations_view_model')
-    end
-
-    it '/quota_definitions redirects as expected' do
-      get_redirects_as_expected('/quota_definitions')
-    end
-
-    it '/quotas_view_model redirects as expected' do
-      get_redirects_as_expected('/quotas_view_model')
-    end
-
-    it '/routers redirects as expected' do
-      get_redirects_as_expected('/routers')
-    end
-
-    it '/routers_view_model redirects as expected' do
-      get_redirects_as_expected('/routers_view_model')
-    end
-
-    it '/routes redirects as expected' do
-      get_redirects_as_expected('/routes')
-    end
-
-    it '/routes_view_model redirects as expected' do
-      get_redirects_as_expected('/routes_view_model')
-    end
-
-    it '/settings redirects as expected' do
-      get_redirects_as_expected('/settings')
-    end
-
-    it '/services redirects as expected' do
-      get_redirects_as_expected('/services')
-    end
-
-    it '/service_bindings redirects as expected' do
-      get_redirects_as_expected('/service_bindings')
-    end
-
-    it '/service_brokers redirects as expected' do
-      get_redirects_as_expected('/service_brokers')
-    end
-
-    it '/service_instances redirects as expected' do
-      get_redirects_as_expected('/service_instances')
-    end
-
-    it '/service_instances_view_model redirects as expected' do
-      get_redirects_as_expected('/service_instances_view_model')
-    end
-
-    it '/service_plans redirects as expected' do
-      get_redirects_as_expected('/service_plans')
-    end
-
-    it '/service_plans_view_model redirects as expected' do
-      get_redirects_as_expected('/service_plans_view_model')
-    end
-
-    it '/spaces redirects as expected' do
-      get_redirects_as_expected('/spaces')
-    end
-
-    it '/spaces_view_model redirects as expected' do
-      get_redirects_as_expected('/spaces_view_model')
-    end
-
-    it '/spaces_auditors redirects as expected' do
-      get_redirects_as_expected('/spaces_auditors')
-    end
-
-    it '/spaces_developers redirects as expected' do
-      get_redirects_as_expected('/spaces_developers')
-    end
-
-    it '/spaces_managersd redirects as expected' do
-      get_redirects_as_expected('/spaces_managers')
-    end
-
-    it '/tasks redirects as expected' do
-      get_redirects_as_expected('/tasks')
-    end
-
-    it '/tasks_view_model redirects as expected' do
-      get_redirects_as_expected('/tasks_view_model')
-    end
-
-    it '/task_status redirects as expected' do
-      get_redirects_as_expected('/task_status')
-    end
-
-    it '/users redirects as expected' do
-      get_redirects_as_expected('/users')
-    end
-
-    it 'deletes /applications/:app_guid redirects as expected' do
-      delete_redirects_as_expected('/applications/application1')
-    end
-
-    it 'deletes /organizations/:org_guid redirects as expected' do
-      delete_redirects_as_expected('/organizations/organization1')
-    end
-
-    it 'deletes /routes/:route_guid redirects as expected' do
-      delete_redirects_as_expected('/routes/route1')
-    end
-
-    it 'posts /organizations redirects as expected' do
-      post_redirects_as_expected('/organizations', '{"name":"new_org"}')
-    end
-
-    it 'puts /applications/:app_guid redirects as expected' do
-      put_redirects_as_expected('/applications/application1', '{"state":"STARTED"}')
-    end
-
-    it 'puts /organizations/:org_guid redirects as expected' do
-      put_redirects_as_expected('/organizations/organization1', '{"quota_definition_guid":"quota1"}')
-    end
-
-    it 'puts /service_plans/:service_plan_guid redirects as expected' do
-      put_redirects_as_expected('/service_plans/application1', '{"public":true}')
+    context '/all tabs via https' do
+      let(:secured_client_connection) { true }
+      it_behaves_like('common /all tabs redirect')
     end
   end
 
   context 'Login not required' do
-    let(:http) { create_http }
 
     def get_response(path)
       request = Net::HTTP::Get.new(path)
@@ -666,90 +834,132 @@ describe AdminUI::Admin do
       body
     end
 
-    it '/favicon.ico succeeds' do
-      get_response('/favicon.ico')
+    shared_examples 'common Login not required' do
+      before do
+        login_stub_fail
+      end
+      let(:http) { create_http }
+
+      it '/favicon.ico succeeds' do
+        get_response('/favicon.ico')
+      end
+
+      it '/stats succeeds' do
+        get_body('/stats')
+      end
+
+      it '/stats_view_model succeeds' do
+        get_body('/stats_view_model')
+      end
     end
 
-    it '/stats succeeds' do
-      get_body('/stats')
+    context 'Login not required via http' do
+      it_behaves_like('common Login not required')
     end
 
-    it '/stats_view_model succeeds' do
-      get_body('/stats_view_model')
+    context 'Login not required via https' do
+      let(:secured_client_connection) { true }
+      it_behaves_like('common Login not required')
     end
-
   end
 
   context 'Statistics' do
-    let(:http) { create_http }
+    shared_examples 'common Statistics' do
+      before do
+        login_stub_fail
+      end
+      let(:http) { create_http }
 
-    it '/current_statistics succeeds' do
-      request = Net::HTTP::Get.new('/current_statistics')
+      it '/current_statistics succeeds' do
+        request = Net::HTTP::Get.new('/current_statistics')
 
-      response = http.request(request)
-      expect(response.is_a?(Net::HTTPOK)).to be_true
+        response = http.request(request)
+        expect(response.is_a?(Net::HTTPOK)).to be_true
 
-      body = response.body
-      expect(body).to_not be_nil
+        body = response.body
+        expect(body).to_not be_nil
 
-      json = JSON.parse(body)
+        json = JSON.parse(body)
 
-      expect(json).to include('apps'              => nil,
-                              'deas'              => nil,
-                              'organizations'     => nil,
-                              'running_instances' => nil,
-                              'spaces'            => nil,
-                              'total_instances'   => nil,
-                              'users'             => nil)
+        expect(json).to include('apps'              => nil,
+                                'deas'              => nil,
+                                'organizations'     => nil,
+                                'running_instances' => nil,
+                                'spaces'            => nil,
+                                'total_instances'   => nil,
+                                'users'             => nil)
+      end
+    end
+
+    context 'Statistics via http' do
+      it_behaves_like('common Statistics')
+    end
+
+    context 'Statistics via https' do
+      let(:secured_client_connection) { true }
+      it_behaves_like('common Statistics')
     end
 
     context 'Login required for post' do
-      before do
-        login_stub_admin
+      shared_examples 'common Login required for post' do
+        before do
+          login_stub_admin
+        end
+        let(:http) { create_http }
+        let(:cookie) { login_and_return_cookie(http) }
+        let(:timestamp) { Time.now }
+
+        it '/statistics post succeeds' do
+          request = Net::HTTP::Post.new('/statistics?apps=1&deas=2&organizations=3&running_instances=4&spaces=5&timestamp=6&total_instances=7&users=8')
+          request['Cookie']         = cookie
+          request['Content-Length'] = 0
+
+          response = http.request(request)
+          expect(response.is_a?(Net::HTTPOK)).to be_true
+
+          body = response.body
+          expect(body).to_not be_nil
+
+          json = JSON.parse(body)
+          expect(json).to eq('apps'              => 1,
+                             'deas'              => 2,
+                             'organizations'     => 3,
+                             'running_instances' => 4,
+                             'spaces'            => 5,
+                             'timestamp'         => 6,
+                             'total_instances'   => 7,
+                             'users'             => 8)
+
+          # Second half of the test does not require cookie for request
+
+          request = Net::HTTP::Get.new('/statistics')
+
+          response = http.request(request)
+          expect(response.is_a?(Net::HTTPOK)).to be_true
+
+          body = response.body
+          expect(body).to_not be_nil
+          json = JSON.parse(body)
+
+          expect(json).to eq('label' => cloud_controller_uri,
+                             'items' => [{ 'apps'              => 1,
+                                           'deas'              => 2,
+                                           'organizations'     => 3,
+                                           'running_instances' => 4,
+                                           'spaces'            => 5,
+                                           'timestamp'         => 6,
+                                           'total_instances'   => 7,
+                                           'users'             => 8 }])
+        end
       end
-      let(:cookie) { login_and_return_cookie(http) }
-      let(:timestamp) { Time.now }
-      it '/statistics post succeeds' do
-        request = Net::HTTP::Post.new('/statistics?apps=1&deas=2&organizations=3&running_instances=4&spaces=5&timestamp=6&total_instances=7&users=8')
-        request['Cookie']         = cookie
-        request['Content-Length'] = 0
 
-        response = http.request(request)
-        expect(response.is_a?(Net::HTTPOK)).to be_true
+      context 'Login required for post via http' do
+        it_behaves_like('common Login required for post')
+      end
 
-        body = response.body
-        expect(body).to_not be_nil
-
-        json = JSON.parse(body)
-        expect(json).to eq('apps'              => 1,
-                           'deas'              => 2,
-                           'organizations'     => 3,
-                           'running_instances' => 4,
-                           'spaces'            => 5,
-                           'timestamp'         => 6,
-                           'total_instances'   => 7,
-                           'users'             => 8)
-
-        # Second half of the test does not require cookie for request
-
-        request = Net::HTTP::Get.new('/statistics')
-
-        response = http.request(request)
-        expect(response.is_a?(Net::HTTPOK)).to be_true
-
-        body = response.body
-        expect(body).to_not be_nil
-        json = JSON.parse(body)
-
-        expect(json).to eq('label' => cloud_controller_uri,
-                           'items' => [{ 'apps'              => 1,
-                                         'deas'              => 2,
-                                         'organizations'     => 3,
-                                         'running_instances' => 4,
-                                         'spaces'            => 5,
-                                         'timestamp'         => 6,
-                                         'total_instances'   => 7,
-                                         'users'             => 8 }])
+      context 'Login required for post via https' do
+        let(:secured_client_connection) { true }
+        it_behaves_like('common Login required for post')
       end
     end
   end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -109,6 +109,11 @@ describe AdminUI::Config do
         expect(config.receiver_emails).to eq(receiver_emails)
       end
 
+      it 'secured_client_connection' do
+        config = AdminUI::Config.load('secured_client_connection' => true)
+        expect(config.secured_client_connection).to eq(true)
+      end
+
       context 'sender_email' do
         let(:sender_email) { { 'server' => 'localhost', 'account' => 'bogus@localhost.com' } }
         let(:config) { AdminUI::Config.load('sender_email' => sender_email) }
@@ -119,6 +124,27 @@ describe AdminUI::Config do
 
         it 'sender_email_server' do
           expect(config.sender_email_server).to eq(sender_email['server'])
+        end
+      end
+
+      context 'ssl is in use' do
+        let(:ssl) { { 'certificate_file_path'    => 'certificate_file_path', 'private_key_file_path'    => 'private_key_file_path', 'private_key_pass_phrase'  => 'private_key_pass_phrase', 'max_session_idle_length'  => 4 } }
+        let(:config) { AdminUI::Config.load('ssl' => ssl) }
+
+        it 'ssl_certificate_file_path' do
+          expect(config.ssl_certificate_file_path).to eq('certificate_file_path')
+        end
+
+        it 'ssl_private_key_file_path' do
+          expect(config.ssl_private_key_file_path).to eq('private_key_file_path')
+        end
+
+        it 'ssl_private_key_pass_phrase' do
+          expect(config.ssl_private_key_pass_phrase).to eq('private_key_pass_phrase')
+        end
+
+        it 'max_session_idle_length' do
+          expect(config.ssl_max_session_idle_length).to eq(4)
         end
       end
 
@@ -320,6 +346,10 @@ describe AdminUI::Config do
         expect(config.receiver_emails).to eq([])
       end
 
+      it 'secured_client_connection' do
+        expect(config.secured_client_connection).to eq(false)
+      end
+
       context 'sender_email' do
         it 'sender_email_account' do
           expect(config.sender_email_account).to be_nil
@@ -327,6 +357,24 @@ describe AdminUI::Config do
 
         it 'sender_email_server' do
           expect(config.sender_email_server).to be_nil
+        end
+      end
+
+      context 'ssl' do
+        it 'ssl_certificate_file_path to be nil' do
+          expect(config.ssl_certificate_file_path).to be_nil
+        end
+
+        it 'ssl_private_key_file_path' do
+          expect(config.ssl_private_key_file_path).to be_nil
+        end
+
+        it 'ssl_private_key_pass_phrase' do
+          expect(config.ssl_private_key_pass_phrase).to be_nil
+        end
+
+        it 'max_session_idle_length' do
+          expect(config.ssl_max_session_idle_length).to be_nil
         end
       end
 
@@ -467,6 +515,10 @@ describe AdminUI::Config do
         expect { AdminUI::Config.load(config.merge(:receiver_emails => [1, 2, 3])) }.to raise_error(Membrane::SchemaValidationError)
       end
 
+      it 'secured_client_connection' do
+        expect { AdminUI::Config.load(config.merge(:secured_client_connection => 'hi')) }.to raise_error(Membrane::SchemaValidationError)
+      end
+
       context 'sender_email' do
         it 'sender_email_account' do
           expect { AdminUI::Config.load(config.merge(:sender_email => { :account => 5, :server => 'hi'  })) }.to raise_error(Membrane::SchemaValidationError)
@@ -474,6 +526,24 @@ describe AdminUI::Config do
 
         it 'sender_email_server' do
           expect { AdminUI::Config.load(config.merge(:sender_email => { :account => 'hi', :server => 5  })) }.to raise_error(Membrane::SchemaValidationError)
+        end
+      end
+
+      context 'ssl' do
+        it 'ssl_certificate_file_path' do
+          expect { AdminUI::Config.load(config.merge(:ssl => { :certificate_file_path => 1,  :private_key_file_path => 'hi', :private_key_pass_phrase => 'hi', :max_session_idle_length => 1 })) }.to raise_error(Membrane::SchemaValidationError)
+        end
+
+        it 'ssl_private_key_file_path' do
+          expect { AdminUI::Config.load(config.merge(:ssl => { :certificate_file_path => 'hi',  :private_key_file_path => 1, :private_key_pass_phrase => 'hi', :max_session_idle_length => 1 })) }.to raise_error(Membrane::SchemaValidationError)
+        end
+
+        it 'ssl_private_key_pass_phrase' do
+          expect { AdminUI::Config.load(config.merge(:ssl => { :certificate_file_path => 'hi',  :private_key_file_path => 'hi', :private_key_pass_phrase => 1, :max_session_idle_length => 1 })) }.to raise_error(Membrane::SchemaValidationError)
+        end
+
+        it 'max_session_idle_length' do
+          expect { AdminUI::Config.load(config.merge(:ssl => { :certificate_file_path => 'hi',  :private_key_file_path => 'hi', :private_key_pass_phrase => 'hi', :max_session_idle_length => 'hi' })) }.to raise_error(Membrane::SchemaValidationError)
         end
       end
 
@@ -573,8 +643,30 @@ describe AdminUI::Config do
         expect { AdminUI::Config.load(config.merge(:port => nil)) }.to raise_error(Membrane::SchemaValidationError)
       end
 
+      it 'secured_client_connection' do
+        expect { AdminUI::Config.load(config.merge(:secured_client_connection => nil)) }.to raise_error(Membrane::SchemaValidationError)
+      end
+
       it 'stats_file' do
         expect { AdminUI::Config.load(config.merge(:stats_file => nil)) }.to raise_error(Membrane::SchemaValidationError)
+      end
+
+      context 'ssl' do
+        it 'ssl_certificate_file_path' do
+          expect { AdminUI::Config.load(config.merge(:ssl => { :private_key_file_path => 'hi', :private_key_pass_phrase => 'hi', :max_session_idle_length => 1 })) }.to raise_error(Membrane::SchemaValidationError)
+        end
+
+        it 'ssl_private_key_file_path' do
+          expect { AdminUI::Config.load(config.merge(:ssl => { :certificate_file_path => 'hi',  :private_key_pass_phrase => 'hi', :max_session_idle_length => 1 })) }.to raise_error(Membrane::SchemaValidationError)
+        end
+
+        it 'ssl_private_key_pass_phrase' do
+          expect { AdminUI::Config.load(config.merge(:ssl => { :certificate_file_path => 'hi',  :private_key_file_path => 'hi', :max_session_idle_length => 1 })) }.to raise_error(Membrane::SchemaValidationError)
+        end
+
+        it 'max_session_idle_length' do
+          expect { AdminUI::Config.load(config.merge(:ssl => { :certificate_file_path => 'hi',  :private_key_file_path => 'hi', :private_key_pass_phrase => 'hi' })) }.to raise_error(Membrane::SchemaValidationError)
+        end
       end
 
       context 'uaa_client' do


### PR DESCRIPTION
Prior to this PR, Admin-UI only operates in unprotected mode - all communication with its web clients goes through plain HTTP protocol.  To some users, the lack of SSL/HTTPS enablement is a security concern.  This PR aims at addressing this concern by enabling Admin-UI to operate in secure mode while unprotected mode remains as the default behavior.
