### PR TITLE
fixed js script injection bug

### DIFF
--- a/lib/admin.rb
+++ b/lib/admin.rb
@@ -73,6 +73,14 @@ module AdminUI
     end
 
     def display_files
+      unless @testing
+        puts "\n\n"
+        puts 'AdminUI files...'
+        puts "  data:  #{ @config.data_file }"
+        puts "  log:   #{ @config.log_file }"
+        puts "  stats: #{ @config.db_uri }"
+        puts "\n"
+      end
     end
 
     def launch_web

--- a/lib/admin/public/js/app/format.js
+++ b/lib/admin/public/js/app/format.js
@@ -3,6 +3,17 @@ var Format =
 {
     raw: false,
 
+    handleNullString: function(value)
+    {
+        return (value != null) ? value : "";
+    },
+
+    handleScriptInjection: function(value)
+    {
+    	var solidValue = Format.handleNullString(value);
+        return solidValue.replace(/<\/?[^>]+(>|$)/g, "");
+    },
+
     doFormatting: function(type)
     {
         if (Format.raw)
@@ -40,7 +51,8 @@ var Format =
 
     formatApplicationName: function(name, type, item)
     {
-        return Format.formatTruncatedString(name, type, item, 30);
+        var sanitizedName = Format.handleScriptInjection(name)
+        return Format.formatTruncatedString(sanitizedName, type, item, 30);
     },
 
     formatAvailableCapacity: function(capacity, type, item)
@@ -336,7 +348,7 @@ var Format =
 
     formatOrganizationName: function(name, type, item)
     {
-        return Format.formatTruncatedString(name, type, item, 20);
+        return Format.formatStringTooltip(name, type, item, 20);
     },
 
     formatOrganizationStatus: function(status, type, item)
@@ -369,12 +381,12 @@ var Format =
 
     formatServiceString: function(name, type, item)
     {
-        return Format.formatTruncatedString(name, type, item, 30);
+        return Format.formatStringTooltip(name, type, item, 30);
     },
 
     formatSpaceName: function(name, type, item)
     {
-        return Format.formatTruncatedString(name, type, item, 20);
+        return Format.formatStringTooltip(name, type, item, 20);
     },
 
     formatStacks: function(values, type, item)
@@ -469,12 +481,23 @@ var Format =
 
     formatString: function(value)
     {
-        return (value != null) ? value : "";
+        return Format.handleNullString(value);
+    },
+
+    formatStringCleansed: function(value)
+    {
+    	return Format.handleScriptInjection(value)
+    },
+
+    formatStringTooltip: function(value, type, item, length)
+    {
+    	sanitizedValue = Format.handleScriptInjection(value)
+    	return Format.formatTruncatedString(sanitizedValue, type, item, length);
     },
 
     formatTarget: function(name, type, item)
     {
-        return Format.formatTruncatedString(name, type, item, 30);
+        return Format.formatStringTooltip(name, type, item, 30);
     },
 
     formatTruncatedString: function(value, type, item, length)

--- a/lib/admin/public/js/app/tabs/applicationsTab.js
+++ b/lib/admin/public/js/app/tabs/applicationsTab.js
@@ -326,7 +326,7 @@ ApplicationsTab.prototype.showDetails = function(table, objects, row)
         var spaceLink = document.createElement("a");
         $(spaceLink).attr("href", "");
         $(spaceLink).addClass("tableLink");
-        $(spaceLink).html(Format.formatString(space.name));
+        $(spaceLink).html(Format.formatStringCleansed(space.name));
         $(spaceLink).click(function()
         {
             // Select based on org/space target since space name is not unique.
@@ -343,7 +343,7 @@ ApplicationsTab.prototype.showDetails = function(table, objects, row)
         var organizationLink = document.createElement("a");
         $(organizationLink).attr("href", "");
         $(organizationLink).addClass("tableLink");
-        $(organizationLink).html(Format.formatString(organization.name));
+        $(organizationLink).html(Format.formatStringCleansed(organization.name));
         $(organizationLink).click(function()
         {
             AdminUI.showOrganizations(Format.formatString(organization.name));

--- a/lib/admin/public/js/app/tabs/developersTab.js
+++ b/lib/admin/public/js/app/tabs/developersTab.js
@@ -19,7 +19,7 @@ DevelopersTab.prototype.getColumns = function()
                {
                    "sTitle": "Email",
                    "sWidth": "200px",
-                   "mRender": Format.formatString
+                   "mRender": Format.formatStringCleansed
                },
                {
                    "sTitle": "Space",
@@ -78,7 +78,7 @@ DevelopersTab.prototype.showDetails = function(table, user, row)
         var spaceLink = document.createElement("a");
         $(spaceLink).attr("href", "");
         $(spaceLink).addClass("tableLink");
-        $(spaceLink).html(Format.formatString(row[1]));
+        $(spaceLink).html(Format.formatStringCleansed(row[1]));
         $(spaceLink).click(function()
         {
             // Select based on org/space target since space name is not unique.
@@ -95,7 +95,7 @@ DevelopersTab.prototype.showDetails = function(table, user, row)
         var organizationLink = document.createElement("a");
         $(organizationLink).attr("href", "");
         $(organizationLink).addClass("tableLink");
-        $(organizationLink).html(Format.formatString(row[2]));
+        $(organizationLink).html(Format.formatStringCleansed(row[2]));
         $(organizationLink).click(function()
         {
             AdminUI.showOrganizations(Format.formatString(row[2]));

--- a/lib/admin/public/js/app/tabs/gatewaysTab.js
+++ b/lib/admin/public/js/app/tabs/gatewaysTab.js
@@ -26,7 +26,7 @@ GatewaysTab.prototype.getColumns = function()
                {
                    "sTitle":  "Name",
                    "sWidth":  "100px",
-                   "mRender": Format.formatString
+                   "mRender": Format.formatStringCleansed
                },
                {
                    "sTitle":  "Index",
@@ -47,7 +47,7 @@ GatewaysTab.prototype.getColumns = function()
                {
                    "sTitle":  "Description",
                    "sWidth":  "200px",
-                   "mRender": Format.formatString
+                   "mRender": Format.formatStringCleansed
                },
                {
                    "sTitle":  "CPU",

--- a/lib/admin/public/js/app/tabs/routesTab.js
+++ b/lib/admin/public/js/app/tabs/routesTab.js
@@ -48,7 +48,9 @@ RoutesTab.prototype.getColumns = function()
                },
                {
                    "sTitle":  "Target",
-                   "sWidth":  "180px"
+                   "sWidth":  "200px",
+                   "sClass":  "cellLeftAlign",
+                   "mRender": Format.formatTarget
                },
                {
                    "sTitle":  "Application",
@@ -111,7 +113,7 @@ RoutesTab.prototype.showDetails = function(table, objects, row)
         var spaceLink = document.createElement("a");
         $(spaceLink).attr("href", "");
         $(spaceLink).addClass("tableLink");
-        $(spaceLink).html(Format.formatString(space.name));
+        $(spaceLink).html(Format.formatStringCleansed(space.name));
         $(spaceLink).click(function()
         {
             // Select based on org/space target since space name is not unique.
@@ -128,7 +130,7 @@ RoutesTab.prototype.showDetails = function(table, objects, row)
         var organizationLink = document.createElement("a");
         $(organizationLink).attr("href", "");
         $(organizationLink).addClass("tableLink");
-        $(organizationLink).html(Format.formatString(organization.name));
+        $(organizationLink).html(Format.formatStringCleansed(organization.name));
         $(organizationLink).click(function()
         {
             AdminUI.showOrganizations(Format.formatString(organization.name));

--- a/lib/admin/public/js/app/tabs/serviceInstancesTab.js
+++ b/lib/admin/public/js/app/tabs/serviceInstancesTab.js
@@ -236,7 +236,7 @@ ServiceInstancesTab.prototype.showDetails = function(table, target, row)
         var servicePlanLink = document.createElement("a");
         $(servicePlanLink).attr("href", "");
         $(servicePlanLink).addClass("tableLink");
-        $(servicePlanLink).html(Format.formatString(servicePlan.name));
+        $(servicePlanLink).html(Format.formatStringCleansed(servicePlan.name));
         $(servicePlanLink).click(function()
         {
             AdminUI.showServicePlans(Format.formatString(row[12]));
@@ -257,7 +257,7 @@ ServiceInstancesTab.prototype.showDetails = function(table, target, row)
         var spaceLink = document.createElement("a");
         $(spaceLink).attr("href", "");
         $(spaceLink).addClass("tableLink");
-        $(spaceLink).html(Format.formatString(space.name));
+        $(spaceLink).html(Format.formatStringCleansed(space.name));
         $(spaceLink).click(function()
         {
             // Select based on org/space target since space name is not unique.
@@ -274,7 +274,7 @@ ServiceInstancesTab.prototype.showDetails = function(table, target, row)
         var organizationLink = document.createElement("a");
         $(organizationLink).attr("href", "");
         $(organizationLink).addClass("tableLink");
-        $(organizationLink).html(Format.formatString(organization.name));
+        $(organizationLink).html(Format.formatStringCleansed(organization.name));
         $(organizationLink).click(function()
         {
             AdminUI.showOrganizations(organization.name);

--- a/lib/admin/public/js/app/tabs/servicePlansTab.js
+++ b/lib/admin/public/js/app/tabs/servicePlansTab.js
@@ -69,7 +69,7 @@ ServicePlansTab.prototype.getColumns = function()
                 {
                     "sTitle" : "Version",
                     "sWidth" : "100px",
-                    "mRender" : Format.formatServiceString
+                    "mRender" : Format.formatString
                 },
                 {
                     "sTitle" : "Created",

--- a/lib/admin/public/js/app/tabs/spacesTab.js
+++ b/lib/admin/public/js/app/tabs/spacesTab.js
@@ -158,7 +158,7 @@ SpacesTab.prototype.showDetails = function(table, target, row)
         var organizationLink = document.createElement("a");
         $(organizationLink).attr("href", "");
         $(organizationLink).addClass("tableLink");
-        $(organizationLink).html(Format.formatString(organization.name));
+        $(organizationLink).html(Format.formatStringCleansed(organization.name));
         $(organizationLink).click(function()
         {
             AdminUI.showOrganizations(organization.name);

--- a/spec/integration/web/admin_spec.rb
+++ b/spec/integration/web/admin_spec.rb
@@ -72,6 +72,108 @@ describe AdminUI::Admin, :type => :integration, :firefox_available => true do
       expect(@driver.find_element(:class => 'user').text).to eq('admin')
     end
 
+    context 'formatStringCleansed' do
+      it 'removes html tags for iframe' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<iframe src=javascript:alert(1208)></iframe>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for iframe short form' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<iframe src=javascript:alert(1208)/>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for img' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<img src=javascript:alert(1208)></img>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for img short form' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<img src=javascript:alert(1208)>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for img forward slash' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<img/src='' onerror=alert(9)>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for img dangling quoted string' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<a'' href'' onclick=alert(9)>foo</a>\")")).to eq('hellofoo')
+      end
+
+      it 'removes html tags for CRLF instead of space' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<img%0d%0asrc=''%0d%0aonerror=alert(9)>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for javaScript scheme' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<a href='java&#115;cript:alert(9)'>foo</a>\")")).to eq('hellofoo')
+      end
+
+      it 'removes html tags for unquoted' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<input type=text name=foo value=a%20onchange=alert(9)>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for double-quoted' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<input type='text' name='foo' value='\'onclick=alert(9)//'>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for HTML5 autofocus' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<input type='text' name='foo' value=''onclick=alert(9)//'>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for src & href attributes' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<script src='data:,alert(9)'></script>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for src & href attributes 2' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<script src='data:text/javascript,alert(9)'></script>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for Base64 data' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<a href='data:text/html;base64,PHNjcmlwdD5hbGVydCg5KTwvc2NyaXB0Pg'>foo</a>\")")).to eq('hellofoo')
+      end
+
+      it 'removes html tags for alternate character sets' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<a href=data:text/html;charset=utf-16,%ff%fe%3c%00s%00c%00r%00i%00p%00t%00%3e%00a%00l%00e%00r%00t%00(%009%00)%00/%00s%00c%00r%00i%00p%00t%00'>foo</a>\")")).to eq('hellofoo')
+      end
+
+      it 'removes html tags for SVG 1' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<svg onload='javascript:alert(9)' xmlns='http://www.w3.org/2000/svg'></svg>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for SVG 2' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<g onload='javascript:alert(9)'></g></svg>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for SVG 3' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<a xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='javascript:alert(9)'>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for SVG 4' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<rect width='1000' height='1000' fill='white'/></a></svg>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for missing greater-than sign' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<script%0d%0aalert(9)</script>\")")).to eq('hello')
+      end
+
+      it 'removes html tags for uncommon syntax' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<a''id=a href=''onclick=alert(9)>foo</a>\")")).to eq('hellofoo')
+      end
+
+      it 'removes html tags for orphan entity' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<a href=''&amp;/onclick=alert(9)>foo</a>\")")).to eq('hellofoo')
+      end
+
+      it 'removes any html tags' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<xyz src=javascript:alert(1208)></xzy>\")")).to eq('hello')
+      end
+
+      it 'removes any html tags shorm form 1' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<xyz src=javascript:alert(1208) />\")")).to eq('hello')
+      end
+
+      it 'removes any html tags shorm form 2' do
+        expect(@driver.execute_script("return Format.formatStringCleansed(\"hello<xyz src=javascript:alert(1208) >\")")).to eq('hello')
+      end
+    end
+
     context 'tabs' do
       let(:table_has_data) { true }
       before do


### PR DESCRIPTION
Some CF components such as organizations, spaces, apps, service plans and etc depend on user inputs for their names.  Prior to this PR, admin-ui directly renders these inputs almost without any safeguard measure.  This behavior allows malicious users to deliberately embed JavaScript programs in these names.  When rendering these user inputs on the main tables, browser can trigger invocation of these embedded programs which can cause annoyance or even harms to the admin-ui's end users.  This problem is known as  Javascript injection.  This PR aims at addressing this security problem.

As a fix, the display logic on the main tables now removes all embedded HTML tags from user inputs. The rendering logic for detail tables preserves these user inputs unless they are used in the clickable links.  This measure stop the Javascript injection attach while preserving the originality of user inputs as viewable in the details tables.
