### PR TITLE
add user actions to log

### DIFF
--- a/lib/admin.rb
+++ b/lib/admin.rb
@@ -9,6 +9,7 @@ require_relative 'admin/db/dbstore_migration'
 require_relative 'admin/email'
 require_relative 'admin/login'
 require_relative 'admin/log_files'
+require_relative 'admin/logger'
 require_relative 'admin/nats'
 require_relative 'admin/operation'
 require_relative 'admin/secure_web'
@@ -48,8 +49,7 @@ module AdminUI
     end
 
     def setup_logger
-      @logger = Logger.new(@config.log_file)
-      @logger.level = Logger::DEBUG
+      @logger = AdminUILogger.new(@config.log_file, Logger::DEBUG)
     end
 
     def setup_dbstore

--- a/lib/admin/logger.rb
+++ b/lib/admin/logger.rb
@@ -1,0 +1,30 @@
+require 'net/http'
+require 'logger'
+require_relative 'config'
+
+module AdminUI
+  class AdminUILogger < Logger
+    alias_method :parent_debug, :debug
+    alias_method :parent_info, :info
+
+    def initialize(file_name, level)
+      super(file_name, level)
+    end
+
+    def debug_user(user_name, op, msg)
+      parent_debug("[ #{ user_name } ] : [ #{ op } ] : #{ msg }")
+    end
+
+    def info_user(user_name, op, msg)
+      parent_info("[ #{ user_name } ] : [ #{ op } ] : #{ msg }")
+    end
+
+    def debug(msg)
+      parent_debug("[ -- ] : [ -- ] : #{ msg }")
+    end
+
+    def info(msg)
+      parent_info("[ -- ] : [ -- ] : #{ msg }")
+    end
+  end
+end

--- a/lib/admin/web.rb
+++ b/lib/admin/web.rb
@@ -1,4 +1,5 @@
 require 'sinatra'
+require_relative 'logger'
 require_relative 'view_models/all_actions'
 
 module AdminUI
@@ -40,30 +41,37 @@ module AdminUI
     end
 
     get '/applications_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/applications_view_model'
       AllActions.new(@logger, @view_models.applications, params).items.to_json
     end
 
     get '/cloud_controllers_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/cloud_controllers_view_model'
       AllActions.new(@logger, @view_models.cloud_controllers, params).items.to_json
     end
 
     get '/components_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/components_view_model'
       AllActions.new(@logger, @view_models.components, params).items.to_json
     end
 
     get '/current_statistics' do
+      @logger.info_user session[:username], 'get', '/current_statistics'
       @stats.current_stats.to_json
     end
 
     get '/deas_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/deas_view_model'
       AllActions.new(@logger, @view_models.deas, params).items.to_json
     end
 
     get '/developers_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/developers_view_model'
       AllActions.new(@logger, @view_models.developers, params).items.to_json
     end
 
     get '/download', :auth => [:user] do
+      @logger.info_user session[:username], 'get', "/download?path=#{ params['path'] }"
       file = @log_files.file(params['path'])
       if file.nil?
         redirect_to_login
@@ -78,14 +86,17 @@ module AdminUI
     end
 
     get '/gateways_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/gateways_view_model'
       AllActions.new(@logger, @view_models.gateways, params).items.to_json
     end
 
     get '/health_managers_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/health_managers_view_model'
       AllActions.new(@logger, @view_models.health_managers, params).items.to_json
     end
 
     get '/log', :auth => [:user] do
+      @logger.info_user session[:username], 'get', "/log?path=#{ params['path'] }"
       result = @log_files.content(params['path'], params['start'])
       if result.nil?
         redirect_to_login
@@ -115,6 +126,7 @@ module AdminUI
 
     get '/logout' do
       begin
+        @logger.info_user session[:username], 'get', '/logout'
         session.destroy
         { 'redirect' => @login.logout(request.base_url) }.to_json
       rescue => error
@@ -125,26 +137,32 @@ module AdminUI
     end
 
     get '/logs_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/logs_view_model'
       AllActions.new(@logger, @view_models.logs, params).items.to_json
     end
 
     get '/organizations_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/organizations_view_model'
       AllActions.new(@logger, @view_models.organizations, params).items.to_json
     end
 
     get '/quotas_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/quotas_view_model'
       AllActions.new(@logger, @view_models.quotas, params).items.to_json
     end
 
     get '/routers_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/routers_view_model'
       AllActions.new(@logger, @view_models.routers, params).items.to_json
     end
 
     get '/routes_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/routes_view_model'
       AllActions.new(@logger, @view_models.routes, params).items.to_json
     end
 
     get '/settings', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/settings'
       {
         :admin                  => session[:admin],
         :cloud_controller_uri   => @config.cloud_controller_uri,
@@ -153,36 +171,44 @@ module AdminUI
     end
 
     get '/service_instances_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/service_instances_view_model'
       AllActions.new(@logger, @view_models.service_instances, params).items.to_json
     end
 
     get '/service_plans_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/service_plans_view_model'
       AllActions.new(@logger, @view_models.service_plans, params).items.to_json
     end
 
     get '/spaces_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/spaces_view_model'
       AllActions.new(@logger, @view_models.spaces, params).items.to_json
     end
 
     get '/statistics' do
+      @logger.info_user session[:username], 'get', '/statistics'
       @stats.stats.to_json
     end
 
     get '/stats_view_model' do
+      @logger.info_user session[:username], 'get', '/stats_view_model'
       extended_result = AllActions.new(@logger, @view_models.stats, params).items
       extended_result[:items][:label] = @config.cloud_controller_uri
       extended_result.to_json
     end
 
     get '/stats' do
+      @logger.info_user session[:username], 'get', '/stats'
       send_file File.expand_path('stats.html', settings.public_folder)
     end
 
     get '/tasks_view_model', :auth => [:user] do
+      @logger.info_user session[:username], 'get', '/tasks_view_model'
       AllActions.new(@logger, @view_models.tasks, params).items.to_json
     end
 
     get '/task_status', :auth => [:user] do
+      @logger.info_user session[:username], 'get', "/task_status?task_id=#{ params['task_id'] };updates=#{ params['updates'] }"
       result = @tasks.task(params['task_id'].to_i,
                            params['updates'] || 'false',
                            session[:last_task_update] || 0)
@@ -196,6 +222,7 @@ module AdminUI
     end
 
     post '/deas', :auth => [:admin] do
+      @logger.info_user session[:username], 'post', '/deas'
       result = { :task_id => @tasks.new_dea }
       @view_models.invalidate_tasks
       result.to_json
@@ -204,6 +231,7 @@ module AdminUI
     post '/organizations', :auth => [:admin] do
       begin
         control_message = request.body.read.to_s
+        @logger.info_user session[:username], 'post', "/organizations; body = #{ control_message }"
         @operation.create_organization(control_message)
 
         204
@@ -224,6 +252,19 @@ module AdminUI
                                   :total_instances   => params['total_instances'].empty? ? nil : params['total_instances'].to_i,
                                   :users             => params['users'].empty? ? nil : params['users'].to_i)
 
+      query = '/statistics?'
+      query += "apps=#{ params['apps'] };" unless params['apps'].empty?
+      query += "deas=#{ params['deas'] };" unless params['deas'].empty?
+      query += "organizations=#{ params['organizations'] };" unless params['organizations'].empty?
+      query += "running_instances=#{ params['running_instances'] };" unless params['running_instances'].empty?
+      query += "spaces=#{ params['spaces'] };" unless params['spaces'].empty?
+      query += "timestamp=#{ params['timestamp'] };"
+      query += "total_instances=#{ params['total_instances'] };" unless params['total_instances'].empty?
+      query += "users=#{ params['users'] };" unless params['users'].empty?
+      query = query.chomp(';')
+      query = '/statistics' if query == '/statistics?'
+
+      @logger.info_user session[:username], 'post', query
       halt 500 if stats.nil?
 
       @view_models.invalidate_stats
@@ -235,6 +276,7 @@ module AdminUI
     put '/applications/:app_guid', :auth => [:admin] do
       begin
         control_message = request.body.read.to_s
+        @logger.info_user session[:username], 'put', "/applications/#{ params[:app_guid] }; body = #{ control_message}"
         @operation.manage_application(params[:app_guid], control_message)
 
         204
@@ -248,6 +290,7 @@ module AdminUI
     put '/organizations/:org_guid', :auth => [:admin] do
       begin
         control_message = request.body.read.to_s
+        @logger.info_user session[:username], 'put', "/organizations/#{ params[:org_guid] }; body = #{ control_message }"
         @operation.manage_organization(params[:org_guid], control_message)
 
         204
@@ -261,6 +304,7 @@ module AdminUI
     put '/service_plans/:service_plan_guid', :auth => [:admin] do
       begin
         control_message = request.body.read.to_s
+        @logger.info_user session[:username], 'put', "/service_plans/#{ params[:service_plan_guid] }; body = #{ control_message }"
         @operation.manage_service_plan(params[:service_plan_guid], control_message)
 
         204
@@ -272,6 +316,7 @@ module AdminUI
     end
 
     delete '/applications/:app_guid', :auth => [:admin] do
+      @logger.info_user session[:username], 'delete', "/applications/#{ params[:app_guid] }"
       begin
         @operation.delete_application(params[:app_guid])
         204
@@ -283,12 +328,14 @@ module AdminUI
     end
 
     delete '/components', :auth => [:user] do
+      @logger.info_user session[:username], 'delete', "/components/#{ params[:uri] }"
       @varz.remove(params['uri'])
 
       204
     end
 
     delete '/organizations/:org_guid', :auth => [:admin] do
+      @logger.info_user session[:username], 'delete', "/organizations/#{ params[:org_guid] }"
       begin
         @operation.delete_organization(params[:org_guid])
         204
@@ -300,6 +347,7 @@ module AdminUI
     end
 
     delete '/routes/:route_guid', :auth => [:admin] do
+      @logger.info_user session[:username], 'delete', "/routes/#{ params[:route_guid] }"
       begin
         @operation.delete_route(params[:route_guid])
         204
@@ -321,6 +369,7 @@ module AdminUI
 
       session[:admin] = admin
 
+      @logger.info_user username, 'authenticated', "is admin? #{ admin }"
       redirect "application.html?user=#{ username }", 303
     end
 


### PR DESCRIPTION
Current Admin-UI doesn't not capture user information for their actions performed onto the application.  There is no way of telling who made what changes.  Given this tool can allow users (admins) to modify artifacts in the CF runtime, it is desirable to have individual accountability for Admin UI operations.
This PR aims at enabling this accountability by writing user id, users's operation and time into the log file.
