### PR TITLE
Add mysql2 dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sequel_pg', '1.6.10'
 gem 'sinatra', '1.4.5'
 gem 'sqlite3', '1.3.9'
 gem 'yajl-ruby', '1.2.1'
+gem 'mysql2', '0.3.16'
 
 group :test do
   gem 'rspec', '2.14.1'


### PR DESCRIPTION
We are setting up the ui against a mysql based cloudfoundry install and need mysql included to have bin/admin work.
