### PR TITLE
Adding downcase on table names to get around case sensitivity in MySQL.

### DIFF
--- a/lib/admin/cc.rb
+++ b/lib/admin/cc.rb
@@ -433,6 +433,7 @@ module AdminUI
           table          = cache[:table]
           columns        = cache[:columns]
           db_columns     = connection[table].columns
+          db_columns     = db_columns.map(&:downcase)
           cache[:select] = connection[table].select(columns & db_columns).sql
           # TODO: If the sql has parenthesis around the select clause, you get an array of values instead of a hash
           cache[:select] = cache[:select].sub('(', '').sub(')', '')


### PR DESCRIPTION
When using a MySQL back-end the column names in the DB (displayName, lastModified, etc.) don't match up with what the app is using.  This forces the column names returned from the database to lower case so that the comparison lines up and the fields are included in the returned array.
