### PR TITLE
Adding configuration options for default_page_size and table_height for the dataTable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,25 @@ Seconds between stats collection saving.
 Example: <code>300</code>
 </dd>
 <dt>
+<code>table_height</code>
+<dt>
+<dd>
+Maximum height of the data table, will be set to 300px if not configured.  If the records on the page are too large
+to fit in this height then a vertical scroll bar will appear in the table.  Can be set to either a specific pixel size
+or a percentage.  Using 100% will ensure that all data will be displayed without a scroll bar in the table.
+<br>
+Example: <code>100%</code>
+</dd>
+<dt>
+<code>table_page_size</code>
+<dt>
+<dd>
+Default selection for the page size in the table, will be set to 10 if not configured. Valid values are: 5, 10, 25, 50,
+100, 250, 500, 1000
+<br>
+Example: <code>25</code>
+</dd>
+<dt>
 <code>tasks_refresh_interval</code>
 </dt>
 <dd>
@@ -618,24 +637,6 @@ Example: <code>postgres://uaaadmin:admin@10.244.0.30:5524/uaadb</code>
 Seconds between VARZ discoveries
 <br>
 Example: <code>30</code>
-</dd>
-<dt>
-<code>default_page_size</code>
-<dt>
-<dd>
-Default selection for the page size in the table, will be set to 10 if not configured.
-<br>
-Example: <code>25</code>
-</dd>
-<dt>
-<code>table_height</code>
-<dt>
-<dd>
-Maximum height of the data table, will be set to 300px if not configured.  If the records on the page are too large
-to fit in this height then a vertical scroll bar will appear in the table.  Can be set to either a specific pixel size
-or a percentage.  Using 100% will ensure that all data will be displayed without a scroll bar in the table.
-<br>
-Example: <code>100%</code>
 </dd>
 </dl>
 

--- a/lib/admin/config.rb
+++ b/lib/admin/config.rb
@@ -21,12 +21,12 @@ module AdminUI
       :stats_refresh_schedules             =>      ['0 5 * * *'],
       :stats_retries                       =>                  5,
       :stats_retry_interval                =>                300,
+      :table_height                        =>            '300px',
+      :table_page_size                     =>                 10,
       :tasks_refresh_interval              =>              5_000,
       :uaa_groups_admin                    => ['admin_ui.admin'],
       :uaa_groups_user                     =>  ['admin_ui.user'],
-      :varz_discovery_interval             =>                 30,
-      :default_page_size                   =>                 10,
-      :table_height                        =>            '300px'
+      :varz_discovery_interval             =>                 30
     }
 
     def self.schema
@@ -73,6 +73,8 @@ module AdminUI
           optional(:stats_refresh_schedules)             => [/@yearly|@annually|@monthly|@weekly|@daily|@midnight|@hourly|(((((\d+)((\,|-)(\d+))*)|(\*))([\s]+)){4}+)(((\d+)((\,|-)(\d+))*)|(\*))/],
           optional(:stats_retries)                       => Integer,
           optional(:stats_retry_interval)                => Integer,
+          optional(:table_height)                        => /[^\r\n\t]+/,
+          optional(:table_page_size)                     => enum(5, 10, 25, 50, 100, 250, 500, 1000),
           optional(:tasks_refresh_interval)              => Integer,
           :uaa_client                                    =>
           {
@@ -82,9 +84,7 @@ module AdminUI
           :uaadb_uri                                     => /[^\r\n\t]+/,
           :uaa_groups_admin                              => [/[^\r\n\t]+/],
           :uaa_groups_user                               => [/[^\r\n\t]+/],
-          optional(:varz_discovery_interval)             => Integer,
-          optional(:default_page_size)                   => Integer,
-          optional(:table_height)                        => /[^\r\n\t]+/
+          optional(:varz_discovery_interval)             => Integer
         }
         unless schema[:stats_refresh_schedules].nil?
           schema[:stats_refresh_schedules].each do | spec |
@@ -268,6 +268,14 @@ module AdminUI
       @config[:stats_retry_interval]
     end
 
+    def table_height
+      @config[:table_height]
+    end
+
+    def table_page_size
+      @config[:table_page_size]
+    end
+
     def tasks_refresh_interval
       @config[:tasks_refresh_interval]
     end
@@ -296,14 +304,6 @@ module AdminUI
 
     def varz_discovery_interval
       @config[:varz_discovery_interval]
-    end
-
-    def default_page_size
-      @config[:default_page_size]
-    end
-
-    def table_height
-      @config[:table_height]
     end
 
     private

--- a/lib/admin/public/js/app/table.js
+++ b/lib/admin/public/js/app/table.js
@@ -66,7 +66,7 @@ var Table =
                          "aoColumns":       columns,
                          "sPaginationType": "full_numbers",
                          "aLengthMenu":     [[5, 10, 25, 50, 100, 250, 500, 1000], [5, 10, 25, 50, 100, 250, 500, 1000]],
-                         "iDisplayLength":  AdminUI.settings.default_page_size,
+                         "iDisplayLength":  AdminUI.settings.table_page_size,
                          "sScrollY":        AdminUI.settings.table_height,
                          "bScrollCollapse": true,
                          "sDom":            'T<"clear">lfrtip',

--- a/lib/admin/web.rb
+++ b/lib/admin/web.rb
@@ -264,9 +264,9 @@ module AdminUI
       {
         :admin                  => session[:admin],
         :cloud_controller_uri   => @config.cloud_controller_uri,
-        :tasks_refresh_interval => @config.tasks_refresh_interval,
-        :default_page_size      => @config.default_page_size,
-        :table_height           => @config.table_height
+        :table_height           => @config.table_height,
+        :table_page_size        => @config.table_page_size,
+        :tasks_refresh_interval => @config.tasks_refresh_interval
       }.to_json
     end
 

--- a/spec/unit/admin_spec.rb
+++ b/spec/unit/admin_spec.rb
@@ -23,6 +23,8 @@ describe AdminUI::Admin do
   let(:private_key_pass_phrase) { 'private_key_pass_phrase'  }
   let(:secured_client_connection) { false }
   let(:stats_file) { '/tmp/admin_ui_stats.json' }
+  let(:table_height) { '300px' }
+  let(:table_page_size) { 10 }
   let(:tasks_refresh_interval) { 6000 }
   let(:uaadb_file) { '/tmp/admin_ui_uaadb.db' }
   let(:uaadb_uri)  { "sqlite://#{ uaadb_file }" }
@@ -41,6 +43,8 @@ describe AdminUI::Admin do
                                       :private_key_pass_phrase => private_key_pass_phrase
                                     },
       :stats_file                => stats_file,
+      :table_height              => table_height,
+      :table_page_size           => table_page_size,
       :tasks_refresh_interval    => tasks_refresh_interval,
       :uaadb_uri                 => uaadb_uri,
       :uaa_client                => { :id => 'id', :secret => 'secret' }
@@ -558,6 +562,8 @@ describe AdminUI::Admin do
 
         expect(json).to eq('admin'                  => true,
                            'cloud_controller_uri'   => cloud_controller_uri,
+                           'table_height'           => table_height,
+                           'table_page_size'        => table_page_size,
                            'tasks_refresh_interval' => tasks_refresh_interval)
 
       end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -262,6 +262,18 @@ describe AdminUI::Config do
         expect(config.stats_retry_interval).to eq(stats_retry_interval)
       end
 
+      it 'table_height' do
+        table_height = '300px'
+        config = AdminUI::Config.load('table_height' => table_height)
+        expect(config.table_height).to eq(table_height)
+      end
+
+      it 'table_page_size' do
+        table_page_size = '10'
+        config = AdminUI::Config.load('table_page_size' => table_page_size)
+        expect(config.table_page_size).to eq(table_page_size)
+      end
+
       it 'tasks_refresh_interval' do
         tasks_refresh_interval = 99
         config = AdminUI::Config.load('tasks_refresh_interval' => tasks_refresh_interval)
@@ -445,6 +457,14 @@ describe AdminUI::Config do
 
       it 'stats_retry_interval' do
         expect(config.stats_retry_interval).to eq(300)
+      end
+
+      it 'table_height' do
+        expect(config.table_height).to eq('300px')
+      end
+
+      it 'table_page_size' do
+        expect(config.table_page_size).to eq(10)
       end
 
       it 'tasks_refresh_interval' do
@@ -658,6 +678,14 @@ describe AdminUI::Config do
 
       it 'stats_retry_interval' do
         expect { AdminUI::Config.load(config.merge(:stats_retry_interval => 'hi')) }.to raise_error(Membrane::SchemaValidationError)
+      end
+
+      it 'table_height' do
+        expect { AdminUI::Config.load(config.merge(:table_height => 5)) }.to raise_error(Membrane::SchemaValidationError)
+      end
+
+      it 'table_page_size' do
+        expect { AdminUI::Config.load(config.merge(:table_page_size => 6)) }.to raise_error(Membrane::SchemaValidationError)
       end
 
       it 'tasks_refresh_interval' do


### PR DESCRIPTION
Adding configuration options to allow customizing the default page size in the data table (currently hard coded to 10) and the table height (currently hard coded to 300px).
