### PR TITLE
Update mysql gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'sqlite3', '1.3.9'
 gem 'yajl-ruby', '1.2.1'
 
 group :mysql do
-  gem 'mysql2', '0.3.16'
+  gem 'mysql2', '0.3.18'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     json_pure (1.8.1)
     membrane (1.1.0)
     multi_json (1.10.1)
-    mysql2 (0.3.16)
+    mysql2 (0.3.18)
     nats (0.5.0.beta.14)
       daemons (>= 1.1.9)
       eventmachine (>= 1.0.3)
@@ -62,7 +62,7 @@ PLATFORMS
 
 DEPENDENCIES
   membrane (= 1.1.0)
-  mysql2 (= 0.3.16)
+  mysql2 (= 0.3.18)
   nats (= 0.5.0.beta.14)
   net-sftp (= 2.1.2)
   parse-cron (= 0.1.4)


### PR DESCRIPTION
Hey, all. 

I tent to use mysqlclient with version > 6.1. It is not designed to use with old versions of mysql gem.

I need this changes to fix mysqlclient in admin-ui-boshrelease.

Thank you, 
Alex L.