### PR TITLE
Allow to override the default doppler endpoint

### DIFF
--- a/lib/admin/cc_rest_client.rb
+++ b/lib/admin/cc_rest_client.rb
@@ -195,8 +195,13 @@ module AdminUI
       @authorization_endpoint = body_json['authorization_endpoint']
       raise "Information retrieved from #{get_cc_url('/v2/info')} does not include authorization_endpoint" if @authorization_endpoint.nil?
 
-      @doppler_logging_endpoint = body_json['doppler_logging_endpoint']
-      @logger.warn("Information retrieved from #{get_cc_url('/v2/info')} does not include doppler_logging_endpoint") if @doppler_logging_endpoint.nil?
+      if @config.doppler_logging_endpoint_override.empty?
+        @doppler_logging_endpoint = body_json['doppler_logging_endpoint']
+        @logger.warn("Information retrieved from #{get_cc_url('/v2/info')} does not include doppler_logging_endpoint") if @doppler_logging_endpoint.nil?
+      else
+        @doppler_logging_endpoint = @config.doppler_logging_endpoint_override
+      end
+
 
       @token_endpoint = body_json['token_endpoint']
       raise "Information retrieved from #{get_cc_url('/v2/info')} does not include token_endpoint" if @token_endpoint.nil?

--- a/lib/admin/config.rb
+++ b/lib/admin/config.rb
@@ -11,6 +11,7 @@ module AdminUI
         cloud_controller_ssl_verify_none:                 false,
         component_connection_retries:                         2,
         display_encrypted_values:                          true,
+        doppler_logging_endpoint_override:                   '',
         doppler_reconnect_delay:                            300,
         doppler_rollup_interval:                             30,
         event_days:                                           7,
@@ -46,6 +47,7 @@ module AdminUI
             db_uri:                                           /[^\r\n\t]+/,
             optional(:display_encrypted_values)            => bool,
             doppler_data_file:                                /[^\r\n\t]+/,
+            optional(:doppler_logging_endpoint_override)   => String,
             optional(:doppler_reconnect_delay)             => Integer,
             optional(:doppler_rollup_interval)             => Integer,
             optional(:event_days)                          => Integer,
@@ -170,6 +172,10 @@ module AdminUI
 
     def doppler_data_file
       @config[:doppler_data_file]
+    end
+
+    def doppler_logging_endpoint_override
+      @config[:doppler_logging_endpoint_override]
     end
 
     def doppler_reconnect_delay


### PR DESCRIPTION
- Add optional configuration parameter `doppler_logging_endpoint`
- If `doppler_logging_endpoint` is set, use that one instead of
  asking to the CF api

Hello,

As there is no clear date of when the filtering feature at the source of the metrics will be available and after that it might be necessary some effort on the client side to implement a different request, we still try to file the following pull request to allow to solve the issue today.

we would like to allow the override of default doppler endpoint (taken from a query to the CF api) with an optional custom url in the configuration file.

This will allow us to filter up to 90% of unnecessary metrics and therefore significantly decrease the load on the admin-ui doppler client.
We have also started the internal process to request to open source the nozzle we use to filter the unnecessary requests.

We can of course integrate some tests if the core of the PR looks good.

Best,
Michael