### PR TITLE
Expose cookie settings.

### DIFF
--- a/lib/admin/config.rb
+++ b/lib/admin/config.rb
@@ -27,6 +27,7 @@ module AdminUI
         stats_retry_interval:                               300,
         table_height:                                   '287px',
         table_page_size:                                     10,
+        cookie_secure:                                     true,
         uaa_groups_admin:                    ['admin_ui.admin'],
         uaa_groups_user:                      ['admin_ui.user'],
         varz_discovery_interval:                             30
@@ -84,6 +85,8 @@ module AdminUI
             optional(:stats_retry_interval)                => Integer,
             optional(:table_height)                        => /[^\r\n\t]+/,
             optional(:table_page_size)                     => enum(5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10_000),
+            cookie_secure:                                 bool,
+            cookie_secret:                                 /[^\r\n\t]+/,
             uaa_client:
             {
               id:     /[^\r\n\t]+/,
@@ -315,6 +318,14 @@ module AdminUI
 
     def table_page_size
       @config[:table_page_size]
+    end
+
+    def cookie_secure
+      @config[:cookie_secure]
+    end
+
+    def cookie_secret
+      @config[:cookie_secret]
     end
 
     def uaa_client_id

--- a/lib/admin/secure_web.rb
+++ b/lib/admin/secure_web.rb
@@ -15,7 +15,7 @@ module AdminUI
       set :environment, :production
       set :show_exceptions, false
       use Rack::SSL, exclude: ->(env) { env['RACK_ENV'] != 'production' }
-      use Rack::Session::Cookie, secure: true, expire_after: Config.ssl_max_session_idle_length, secret: 'mysecre'
+      use Rack::Session::Cookie, secure: true, expire_after: Config.ssl_max_session_idle_length, secret: Config.cookie_secret
     end
   end
 end

--- a/lib/admin/web.rb
+++ b/lib/admin/web.rb
@@ -26,6 +26,7 @@ module AdminUI
 
     configure do
       enable :sessions
+      use Rack::Session::Cookie, secure: Config.cookie_secure, secret: Config.cookie_secret
       set :static_cache_control, :no_cache
       set :environment, :production
       set :show_exceptions, false


### PR DESCRIPTION
* Cookie encryption secret should always be set; future versions of rack will require it.
* Allow users to turn on secure cookies without terminating tls in the app.

cc @LinuxBozo