### PR TITLE
Allow secure cookies without terminating TLS.

### DIFF
--- a/lib/admin/config.rb
+++ b/lib/admin/config.rb
@@ -10,7 +10,7 @@ module AdminUI
         cloud_controller_discovery_interval:                300,
         cloud_controller_ssl_verify_none:                 false,
         component_connection_retries:                         2,
-        cookie_secure:                                     true,
+        cookie_secure:                                    false,
         cookie_secret:                                'mysecre',
         display_encrypted_values:                          true,
         doppler_reconnect_delay:                            300,

--- a/lib/admin/config.rb
+++ b/lib/admin/config.rb
@@ -10,6 +10,7 @@ module AdminUI
         cloud_controller_discovery_interval:                300,
         cloud_controller_ssl_verify_none:                 false,
         component_connection_retries:                         2,
+        cookie_secure:                                     true,
         cookie_secret:                                'mysecre',
         display_encrypted_values:                          true,
         doppler_reconnect_delay:                            300,
@@ -43,6 +44,7 @@ module AdminUI
             optional(:cloud_controller_ssl_verify_none)    => bool,
             cloud_controller_uri:                             %r{(http[s]?://[^\r\n\t]+)},
             optional(:component_connection_retries)        => Integer,
+            optional(:cookie_secure)                       => bool,
             optional(:cookie_secret)                       => /[^\r\n\t]+/,
             data_file:                                        /[^\r\n\t]+/,
             db_uri:                                           /[^\r\n\t]+/,
@@ -131,11 +133,16 @@ module AdminUI
 
       # In order to allow class load of Web and SecureWeb to use these values, they have to be static
       # rubocop:disable Style/ClassVars
+      @@cookie_secure               = config_instance.cookie_secure
       @@cookie_secret               = config_instance.cookie_secret
       @@ssl_max_session_idle_length = config_instance.ssl_max_session_idle_length
       # rubocop:enable Style/ClassVars
 
       config_instance
+    end
+
+    def self.cookie_secure
+      @@cookie_secure
     end
 
     def self.cookie_secret
@@ -172,6 +179,10 @@ module AdminUI
 
     def component_connection_retries
       @config[:component_connection_retries]
+    end
+
+    def cookie_secure
+      @config[:cookie_secure]
     end
 
     def cookie_secret

--- a/lib/admin/secure_web.rb
+++ b/lib/admin/secure_web.rb
@@ -10,12 +10,11 @@ module AdminUI
     end
 
     configure do
-      enable :sessions
+      set :sessions, :secure => true, :expire_after => Config.ssl_max_session_idle_length
       set :static_cache_control, :no_cache
       set :environment, :production
       set :show_exceptions, false
       use Rack::SSL, exclude: ->(env) { env['RACK_ENV'] != 'production' }
-      use Rack::Session::Cookie, secure: true, expire_after: Config.ssl_max_session_idle_length, secret: Config.cookie_secret
     end
   end
 end

--- a/lib/admin/web.rb
+++ b/lib/admin/web.rb
@@ -25,8 +25,7 @@ module AdminUI
     end
 
     configure do
-      enable :sessions
-      set :session_secret, Config.cookie_secret
+      set :sessions, :secure => Config.cookie_secure, :secret => Config.cookie_secret
       set :static_cache_control, :no_cache
       set :environment, :production
       set :show_exceptions, false

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -45,6 +45,12 @@ describe AdminUI::Config do
         expect(config.component_connection_retries).to eq(component_connection_retries)
       end
 
+      it 'cookie_secure' do
+        cookie_secure = true
+        config = AdminUI::Config.load('cookie_secure' => cookie_secure)
+        expect(config.cookie_secure).to eq(cookie_secure)
+      end
+
       it 'cookie_secret' do
         cookie_secret = 'mytestingsecret'
         config = AdminUI::Config.load('cookie_secret' => cookie_secret)
@@ -384,6 +390,10 @@ describe AdminUI::Config do
 
       it 'component_connection_retries' do
         expect(config.component_connection_retries).to eq(2)
+      end
+
+      it 'cookie_secure' do
+        expect(config.cookie_secure).to eq(true)
       end
 
       it 'cookie_secret' do


### PR DESCRIPTION
Part of my goal in #182 was to allow the use of secure cookies without terminating tls within the application. I noticed that got dropped from the patch, so here's my second attempt. WDYT @rboykin ?